### PR TITLE
`\usebeamerfont` to follow change of font size in `itemize`

### DIFF
--- a/base/beamerbaseauxtemplates.sty
+++ b/base/beamerbaseauxtemplates.sty
@@ -332,9 +332,9 @@
 
 % Itemize items, circle
 
-\defbeamertemplate{itemize item}{circle}{\small\raise0.5pt\hbox{\textbullet}}
-\defbeamertemplate{itemize subitem}{circle}{\footnotesize\raise0.5pt\hbox{\textbullet}}
-\defbeamertemplate{itemize subsubitem}{circle}{\footnotesize\raise0.5pt\hbox{\textbullet}}
+\defbeamertemplate{itemize item}{circle}{\usebeamerfont*{itemize item}\raise0.5pt\hbox{\textbullet}}
+\defbeamertemplate{itemize subitem}{circle}{\usebeamerfont*{itemize subitem}\raise0.5pt\hbox{\textbullet}}
+\defbeamertemplate{itemize subsubitem}{circle}{\usebeamerfont*{itemize subsubitem}\raise0.5pt\hbox{\textbullet}}
 
 
 

--- a/base/themes/inner/beamerinnerthemedefault.sty
+++ b/base/themes/inner/beamerinnerthemedefault.sty
@@ -170,9 +170,9 @@
 
 % Itemize items, default
 
-\defbeamertemplate*{itemize item}{default}{\scriptsize\raise1.25pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
-\defbeamertemplate*{itemize subitem}{default}{\tiny\raise1.5pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
-\defbeamertemplate*{itemize subsubitem}{default}{\tiny\raise1.5pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
+\defbeamertemplate*{itemize item}{default}{\usebeamerfont*{itemize item}\raise1.25pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
+\defbeamertemplate*{itemize subitem}{default}{\usebeamerfont*{itemize subitem}\raise1.5pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
+\defbeamertemplate*{itemize subsubitem}{default}{\usebeamerfont*{itemize subsubitem}\raise1.5pt\hbox{\donotcoloroutermaths$\blacktriangleright$}}
 
 
 % Enumerate items, default


### PR DESCRIPTION
I occasionally use different font size in `itemize` but the markers do not follow the change, which looks awkward.
This PR will fix that.
