### PR TITLE
Fix typeset_demo_tasks in build.lua

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -109,8 +109,8 @@ function typeset_demo_tasks()
       errorlevel = errorlevel + runtool(
         "", ".",
         "TEXINPUTS",
-        "pdflatex \\def\\themename{" .. theme .. "}"
-          .. "\\input " .. name .. " "
+        "pdflatex << EOF\n\\def\\themename{" .. theme .. "}"
+          .. "\\input " .. name .. "\nEOF"
       )
       if errorlevel ~= 0 then
         return errorlevel


### PR DESCRIPTION
`texlua build.lua doc` raises error like

```
This is pdfTeX, Version 3.14159265-2.6-1.40.19 (TeX Live 2018) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
! I can't find file `defthemename{default}input'.
<*> defthemename{default}input 
                               beamerfontthemeexample.tex
(Press Enter to retry, or Control-D to exit)
Please type another input file name: 
! Emergency stop.
<*> defthemename{default}input 
                               beamerfontthemeexample.tex
!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on texput.log.
```

since <s>`pdflatex '\def\themename{default}\input beamerinnerthemeexample.tex'`</s> `pdflatex defthemename{default}input beamercolorthemeexample.tex` is executed.

Heredoc resolves this—or is there a better way?