### PR TITLE
Update Commands with Overlay Specifications

### DIFF
--- a/base/beamerbaseoverlay.sty
+++ b/base/beamerbaseoverlay.sty
@@ -617,9 +617,14 @@
 {
   \renewcommand<>{\textbf}{\only#1{\beameroriginal{\textbf}}}
   \renewcommand<>{\textit}{\only#1{\beameroriginal{\textit}}}
-  \renewcommand<>{\textsl}{\only#1{\beameroriginal{\textsl}}}
-  \renewcommand<>{\textsf}{\only#1{\beameroriginal{\textsf}}}
+  \renewcommand<>{\textmd}{\only#1{\beameroriginal{\textmd}}}
+  \renewcommand<>{\textnormal}{\only#1{\beameroriginal{\textnormal}}}
   \renewcommand<>{\textrm}{\only#1{\beameroriginal{\textrm}}}
+  \renewcommand<>{\textsc}{\only#1{\beameroriginal{\textsc}}}
+  \renewcommand<>{\textsf}{\only#1{\beameroriginal{\textsf}}}
+  \renewcommand<>{\textsl}{\only#1{\beameroriginal{\textsl}}}
+  \renewcommand<>{\texttt}{\only#1{\beameroriginal{\texttt}}}
+  \renewcommand<>{\textup}{\only#1{\beameroriginal{\textup}}}
 }
 
 \renewcommand<>{\hypertarget}[2]{\only#3{\beameroriginal{\hypertarget}{#1}{#2}}}

--- a/doc/beamerug-overlays.tex
+++ b/doc/beamerug-overlays.tex
@@ -121,7 +121,7 @@ The syntax of (basic) overlay specifications is the following: They are comma-se
 commands documented here are \emph{all} fragile even if the \LaTeXe{} kernel
 versions are not.
 
-For the following commands, adding an overlay specification causes the command to be simply ignored on slides that are not included in the specification: |\textbf|, |\textit|, |\textrm|, |\textsl|, |\textsf|, |\emph|; |\color|, |\textcolor|; |\alert|, |\structure|. If a command takes several arguments, like |\color|, the specification should directly follow the command as in the following example (but there are exceptions to this rule):
+For the following commands, adding an overlay specification causes the command to be simply ignored on slides that are not included in the specification: |\textbf|, |\textit|, |\textmd|, |\textnormal|, |\textrm|, |\textsc|, |\textsf|, |\textsl|, |\texttt|, |\textup|, |\emph|; |\color|, |\textcolor|; |\alert|, |\structure|. If a command takes several arguments, like |\color|, the specification should directly follow the command as in the following example (but there are exceptions to this rule):
 \begin{verbatim}
 \begin{frame}
   \color<2-3>[rgb]{1,0,0} This text is red on slides 2 and 3, otherwise black.

--- a/doc/beamerug-overlays.tex
+++ b/doc/beamerug-overlays.tex
@@ -121,7 +121,7 @@ The syntax of (basic) overlay specifications is the following: They are comma-se
 commands documented here are \emph{all} fragile even if the \LaTeXe{} kernel
 versions are not.
 
-For the following commands, adding an overlay specification causes the command to be simply ignored on slides that are not included in the specification: |\textbf|, |\textit|, |\textsl|, |\textrm|, |\textsf|, |\color|, |\alert|, |\structure|. If a command takes several arguments, like |\color|, the specification should directly follow the command as in the following example (but there are exceptions to this rule):
+For the following commands, adding an overlay specification causes the command to be simply ignored on slides that are not included in the specification: |\textbf|, |\textit|, |\textrm|, |\textsl|, |\textsf|, |\emph|; |\color|, |\textcolor|; |\alert|, |\structure|. If a command takes several arguments, like |\color|, the specification should directly follow the command as in the following example (but there are exceptions to this rule):
 \begin{verbatim}
 \begin{frame}
   \color<2-3>[rgb]{1,0,0} This text is red on slides 2 and 3, otherwise black.


### PR DESCRIPTION
§9.3 lists `\color` as a command with overlay specification,  but so is `\textcolor`.
I'm not sure how other commands are–`\colorbox` and `\fcolorbox` do not work when overlay specification is added.

Also, `\textsc` etc are enabled to be overlaied. 