### PR TITLE
replaced hard coded width of text with the actual width of the inmargin in theme

### DIFF
--- a/base/themes/inner/beamerinnerthemeinmargin.sty
+++ b/base/themes/inner/beamerinnerthemeinmargin.sty
@@ -32,7 +32,7 @@
 \newcommand\beamer@putleft[2]{%
   \hbox to 0pt{\hss\vtop{%
       \normalsize%
-      \@tempdima=.25\paperwidth%
+      \@tempdima=\beamer@leftsidebar%
       \advance\@tempdima by-3ex%
       \hsize=\@tempdima%
       \leftskip=0pt plus 1fill%


### PR DESCRIPTION
The width of the margin text was hard coded to `.25\textwidth`. This PR automatically adapts the width to the width of the sidebar

MWE to reproduce the original problem:

```
\documentclass{beamer}

\useinnertheme{inmargin}
\usecolortheme{crane}

\setbeamersize{sidebar width left=.5\paperwidth}

\begin{document}

\begin{frame}
    \begin{block}{Why is induction motor very common?}

    \end{block}
\end{frame}

\end{document}
```