### PR TITLE
re-introducing `\strut` after `\insertframetitle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ a major and minor version only.
 
 ### Changed
 
+- re-introduced `\strut` after the frametitle (see #535)
 - Promote bookmark level for index (see #554)
 
 ## [v3.57]

--- a/base/themes/outer/beamerouterthemedefault.sty
+++ b/base/themes/outer/beamerouterthemedefault.sty
@@ -158,11 +158,11 @@
     \usebeamerfont{frametitle}%
     \vbox{}\vskip-1ex%
     \if@tempswa\else\csname beamer@fte#1\endcsname\fi%
-    \strut\insertframetitle\par%
+    \strut\insertframetitle\strut\par%
     {%
       \ifx\insertframesubtitle\@empty%
       \else%
-      {\usebeamerfont{framesubtitle}\usebeamercolor[fg]{framesubtitle}\strut\insertframesubtitle\par}%
+      {\usebeamerfont{framesubtitle}\usebeamercolor[fg]{framesubtitle}\strut\insertframesubtitle\strut\par}%
       \fi
     }%
     \vskip-1ex%

--- a/base/themes/outer/beamerouterthemeshadow.sty
+++ b/base/themes/outer/beamerouterthemeshadow.sty
@@ -51,7 +51,7 @@
           \vbox{}\vskip-.75ex%
           \leftskip0.3cm%
           \rightskip0.3cm plus1fil\leavevmode
-          \usebeamercolor[fg]{frametitle}\usebeamerfont{frametitle}\strut\insertframetitle\par%
+          \usebeamercolor[fg]{frametitle}\usebeamerfont{frametitle}\strut\insertframetitle\strut\par%
           \ifx\insertframesubtitle\@empty\else%
             {\usebeamerfont*{framesubtitle}{\usebeamercolor[fg]{framesubtitle}\insertframesubtitle}\strut\par}%
           \fi%

--- a/base/themes/outer/beamerouterthemesmoothbars.sty
+++ b/base/themes/outer/beamerouterthemesmoothbars.sty
@@ -97,11 +97,11 @@
   \vskip-.5ex%
   \nointerlineskip%
   \begin{beamercolorbox}[wd=\paperwidth,leftskip=.3cm,rightskip=.3cm plus1fil,vmode]{frametitle}
-    \usebeamerfont*{frametitle}\insertframetitle%
+    \usebeamerfont*{frametitle}\strut\insertframetitle%
       \ifx\insertframesubtitle\@empty%
         \strut\par%
       \else
-        \par{\usebeamerfont*{framesubtitle}{\usebeamercolor[fg]{framesubtitle}\insertframesubtitle}\strut\par}%
+        \par{\usebeamerfont*{framesubtitle}{\usebeamercolor[fg]{framesubtitle}\strut\insertframesubtitle}\strut\par}%
       \fi%%
     \usebeamerfont{headline}%
     \vskip.5ex  

--- a/base/themes/outer/beamerouterthemesmoothtree.sty
+++ b/base/themes/outer/beamerouterthemesmoothtree.sty
@@ -75,11 +75,11 @@
   \vskip-.5ex%
   \nointerlineskip%
   \begin{beamercolorbox}[wd=\paperwidth,leftskip=.935cm,rightskip=.3cm plus1fil]{frametitle}
-    \usebeamerfont*{frametitle}\insertframetitle%
+    \usebeamerfont*{frametitle}\strut\insertframetitle%
       \ifx\insertframesubtitle\@empty%
         \strut\par%
       \else
-        \par{\usebeamerfont*{framesubtitle}{\usebeamercolor[fg]{framesubtitle}\insertframesubtitle}\strut\par}%
+        \par{\usebeamerfont*{framesubtitle}{\usebeamercolor[fg]{framesubtitle}\strut\insertframesubtitle}\strut\par}%
       \fi%%
     \usebeamerfont{headline}%
     \vskip.5ex  


### PR DESCRIPTION
re-introducing `\strut` after `\insertframetitle` to fix https://github.com/josephwright/beamer/issues/535