### PR TITLE
`externalviewer` option for `\sound` missing in doc

### DIFF
--- a/doc/beamerug-animations.tex
+++ b/doc/beamerug-animations.tex
@@ -354,6 +354,8 @@ The \pdf\ specification introduces special sound objects, which are treated quit
   \item
     \declare{|encoding=|}\meta{method}. Specifies the encoding method, which may be |Raw|, |Signed|, |muLaw|, or |ALaw|. If the method is |muLaw|, this option need not be specified.
   \item
+    \declare{|externalviewer|} causes an external application to be launched for playing the sound. Most options, like |loop|, have no effect since they are not passed along to the external application.
+  \item
     \declare{|height=|}\meta{\TeX\ dimension}. Overrides the height of the \meta{sound poster text} box and sets it to the given dimension.
   \item
     \declare{|inlinesound|} causes the sound data to be stored directly in the \pdf-file.


### PR DESCRIPTION
`externalviewer` option for `\sound` (https://github.com/josephwright/beamer/blob/master/base/multimedia/multimedia.sty#L230) had been missing in the documentation