### PR TITLE
Raise an error for invalid aspectratio

### DIFF
--- a/base/beamer.cls
+++ b/base/beamer.cls
@@ -316,6 +316,9 @@
   \else\ifnum#1=141 %
     \setlength\beamer@paperwidth{14.85cm}%
     \setlength\beamer@paperheight{10.50cm}%
+  \else
+    \ClassError{beamer}{unsupported aspect ratio ``#1'' specified. The supported
+      ratios are: ``1610'', ``169'', ``149'', ``54'', ``43'', ``32'' and ``141''.}{}
   \fi\fi\fi\fi\fi\fi\fi
 }
 


### PR DESCRIPTION
If the user choose to explictly set an aspect ratio, instead of silently
ignoring that choice, beamer will now throw a visible error at compile
time.

I can't think of a situation where I would want an invalid aspectratio to be simply ignored. On the other hand, silently ignoring that error may lead to unwanted surprises later on.