### PR TITLE
Clip \insertslideintonotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ a major and minor version only.
 
 - re-introduced `\strut` after the frametitle (see #535)
 - Promote bookmark level for index (see #554)
+- clip \insertslideintonotes to show only visible area
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ a major and minor version only.
 
 - re-introduced `\strut` after the frametitle (see #535)
 - Promote bookmark level for index (see #554)
-- clip \insertslideintonotes to show only visible area
+- clip `\insertslideintonotes` to show only visible area
 
 ### Fixed
 

--- a/base/beamerbasenotes.sty
+++ b/base/beamerbasenotes.sty
@@ -203,7 +203,7 @@
     \begin{pgflowlevelscope}{\pgftransformscale{#1}}%
       \color{normal text.bg}
       \pgfpathrectangle{\pgfpointorigin}{\pgfpoint{\paperwidth}{\paperheight}}
-      \pgfusepath{fill}
+      \pgfusepath{fill,clip}
       \color{normal text.fg}
       {\pgftransformshift{\pgfpoint{\beamer@origlmargin}{\footheight}}\pgftext[left,bottom]{\copy\beamer@frameboxcopy}}
     \end{pgflowlevelscope}


### PR DESCRIPTION
Restricting `\insertslideintonotes` to only show content within the slide.

MWE to reproduce the problem:
```
\documentclass{beamer}
\setbeameroption{show notes}

\begin{document}

\begin{frame}
\hspace*{-5cm}\color{red}\rule{\paperwidth}{3cm}
\note{note text}
\end{frame}

\end{document}
```

Related problem: https://topanswers.xyz/tex?q=796