### PR TITLE
multimedia needs to be loaded after hyperref

### DIFF
--- a/doc/beamerug-animations.tex
+++ b/doc/beamerug-animations.tex
@@ -26,7 +26,7 @@ To include an animation in a presentation, you can use, for example, the package
 \begin{package}{{multimedia}}
   A stand-alone package that implements several commands for including external animation and sound files in a \pdf\ document. The package can be used together with both |dvips| plus |ps2pdf| and |pdflatex|, though the special sound support is available only in |pdflatex|.
 
-  When including this package, you must also include the |hyperref| package. Since you will typically want to include |hyperref| only at the very end of the preamble, |multimedia| will not include |hyperref| itself. However, |multimedia| can be included both before and after |hyperref|. Since \beamer\ includes |hyperref| automatically, you need not worry about this when creating a presentation using \beamer.
+  When including this package, you must also include the |hyperref| package. The |multimedia| is one of the few packages that needs to be loaded after |hyperref|. Since \beamer\ includes |hyperref| automatically, you need not worry about this when creating a presentation using \beamer.
 \end{package}
 
 For including an animation in a \pdf\ file, you can use the command |\movie|, which is explained below. Depending on the used options, this command will either setup the \pdf\ file such that the viewer application (like the Acrobat Reader) itself will try to play the movie or that an external program will be called. The latter approach, though much less flexible, must be taken if the viewer application is unable to display the movie itself.


### PR DESCRIPTION
The `multimedia` package needs to be loaded after hyperref as demonstrated by this MWE

```
\documentclass{article}

\usepackage{multimedia}
\usepackage{hyperref}

\begin{document}

test

\end{document}
```