### PR TITLE
Restore audio compatibility with Adobe Reader on Windows

### DIFF
--- a/base/multimedia/multimedia.sty
+++ b/base/multimedia/multimedia.sty
@@ -231,7 +231,7 @@
     \else%
       \ifmm@inline%
         \beamer@pdfobj stream
-        attr {\mm@r\space \mm@c\space \mm@b\space \mm@e\space}
+        attr {/Type /Sound \mm@r\space \mm@c\space \mm@b\space \mm@e\space}
         file {#3}%
         \beamer@pdfrefobj \beamer@pdflastobj%
       \else

--- a/base/multimedia/multimedia.sty
+++ b/base/multimedia/multimedia.sty
@@ -231,7 +231,7 @@
     \else%
       \ifmm@inline%
         \beamer@pdfobj stream
-        attr {/Type /Sound \mm@r\space \mm@c\space \mm@b\space}
+        attr {\mm@r\space \mm@c\space \mm@b\space \mm@e\space}
         file {#3}%
         \beamer@pdfrefobj \beamer@pdflastobj%
       \else


### PR DESCRIPTION
fixes #58 (at least for pdftex versions up to and including texlive 2017)