### PR TITLE
Removing obsolete packages/options from examples

### DIFF
--- a/doc/beamerthemeexamplebase.tex
+++ b/doc/beamerthemeexamplebase.tex
@@ -12,8 +12,6 @@
 \beamertemplatesolidbackgroundcolor{black!5}
 \beamertemplatetransparentcovered
 
-\usepackage{times}
-
 \title{There Is No Largest Prime Number}
 \subtitle{With an introduction to a new proof technique}
 

--- a/doc/emulation-examples/beamerexample-prosper.tex
+++ b/doc/emulation-examples/beamerexample-prosper.tex
@@ -9,7 +9,9 @@
 
 % $Header$
 
-\documentclass[notes]{beamer}
+\documentclass{beamer}
+
+\setbeameroption{show notes}
 
 % You might wish to try this instead of the above line:
 %\documentclass[class=article]{beamer}

--- a/doc/emulation-examples/beamerexample-prosper.tex
+++ b/doc/emulation-examples/beamerexample-prosper.tex
@@ -24,7 +24,6 @@
   \definecolor{sidebackground}{RGB}{230,242,250}
   \color{beamerstructure}
   \usetheme{Goettingen}
-  \usepackage{times}
   \userightsidebarcolortemplate{\color{sidebackground}}
   \beamertemplateballitem
 }

--- a/doc/examples/a-conference-talk/beamerexample-conference-talk.tex
+++ b/doc/examples/a-conference-talk/beamerexample-conference-talk.tex
@@ -31,7 +31,6 @@
 
 \usepackage[english]{babel}
 \usepackage[latin1]{inputenc}
-\usepackage{times}
 \usepackage[T1]{fontenc}
 
 

--- a/doc/examples/a-lecture/beamerexample-lecture-style.tex
+++ b/doc/examples/a-lecture/beamerexample-lecture-style.tex
@@ -12,10 +12,8 @@
 
 \usepackage[german]{babel}
 \usepackage[latin1]{inputenc}
-\usepackage{times}
 \mode<article>
 {
-  \usepackage{times}
   \usepackage{mathptmx}
   \usepackage[left=1.5cm,right=6cm,top=1.5cm,bottom=3cm]{geometry}
 }

--- a/doc/solutions/conference-talks/conference-ornate-20min.de.tex
+++ b/doc/solutions/conference-talks/conference-ornate-20min.de.tex
@@ -40,7 +40,6 @@
 \usepackage[latin1]{inputenc}
 % oder was auch immer
 
-\usepackage{times}
 \usepackage[T1]{fontenc}
 % Oder was auch immer. Zu beachten ist, das Font und Encoding passen
 % müssen. Falls T1 nicht funktioniert, kann man versuchen, die Zeile

--- a/doc/solutions/conference-talks/conference-ornate-20min.en.tex
+++ b/doc/solutions/conference-talks/conference-ornate-20min.en.tex
@@ -39,7 +39,6 @@
 \usepackage[latin1]{inputenc}
 % or whatever
 
-\usepackage{times}
 \usepackage[T1]{fontenc}
 % Or whatever. Note that the encoding and the font should match. If T1
 % does not look nice, try deleting the line with the fontenc.

--- a/doc/solutions/conference-talks/conference-ornate-20min.fr.tex
+++ b/doc/solutions/conference-talks/conference-ornate-20min.fr.tex
@@ -38,7 +38,6 @@
 \usepackage[latin1]{inputenc}
 % or autre
 
-\usepackage{times}
 \usepackage[T1]{fontenc}
 % Or autre. Notez que le codage et la fonte doivent être assortis. Si T1
 % ne paraît pas très esthétique, essayer d'effacer la ligne contenant fontenc.

--- a/doc/solutions/generic-talks/generic-ornate-15min-45min.de.tex
+++ b/doc/solutions/generic-talks/generic-ornate-15min-45min.de.tex
@@ -41,7 +41,6 @@
 \usepackage[latin1]{inputenc}
 % oder was auch immer
 
-\usepackage{times}
 \usepackage[T1]{fontenc}
 % Oder was auch immer. Zu beachten ist, das Font und Encoding passen
 % müssen. Falls T1 nicht funktioniert, kann man versuchen, die Zeile

--- a/doc/solutions/generic-talks/generic-ornate-15min-45min.en.tex
+++ b/doc/solutions/generic-talks/generic-ornate-15min-45min.en.tex
@@ -39,7 +39,6 @@
 \usepackage[latin1]{inputenc}
 % or whatever
 
-\usepackage{times}
 \usepackage[T1]{fontenc}
 % Or whatever. Note that the encoding and the font should match. If T1
 % does not look nice, try deleting the line with the fontenc.

--- a/doc/solutions/generic-talks/generic-ornate-15min-45min.fr.tex
+++ b/doc/solutions/generic-talks/generic-ornate-15min-45min.fr.tex
@@ -42,7 +42,6 @@
 \usepackage[latin1]{inputenc}
 % or autre
 
-\usepackage{times}
 \usepackage[T1]{fontenc}
 % Or autre. Notez que le codage et la fonte doivent être assortis. Si T1
 % ne paraît pas très esthétique, essayer d'effacer la ligne contenant fontenc.

--- a/doc/solutions/short-talks/speaker_introduction-ornate-2min.de.tex
+++ b/doc/solutions/short-talks/speaker_introduction-ornate-2min.de.tex
@@ -37,7 +37,6 @@
 \usepackage[latin1]{inputenc}
 % Oder was auch immer
 
-\usepackage{times}
 \usepackage[T1]{fontenc}
 % Oder was auch immer. Zu beachten ist, das Font und Encoding passen
 % müssen. Falls T1 nicht funktioniert, kann man versuchen, die Zeile

--- a/doc/solutions/short-talks/speaker_introduction-ornate-2min.en.tex
+++ b/doc/solutions/short-talks/speaker_introduction-ornate-2min.en.tex
@@ -37,7 +37,6 @@
 \usepackage[latin1]{inputenc}
 % or whatever
 
-\usepackage{times}
 \usepackage[T1]{fontenc}
 % Or whatever. Note that the encoding and the font should match. If T1
 % does not look nice, try deleting the line with the fontenc.

--- a/doc/solutions/short-talks/speaker_introduction-ornate-2min.fr.tex
+++ b/doc/solutions/short-talks/speaker_introduction-ornate-2min.fr.tex
@@ -38,7 +38,6 @@ shading][bottom=white,top=structure.fg!25]
 \usepackage[latin1]{inputenc}
 % or autre
 
-\usepackage{times}
 \usepackage[T1]{fontenc}
 % Or autre. Notez que le codage et la fonte doivent être assortis. Si T1
 % ne paraît pas très esthétique, essayer d'effacer la ligne contenant fontenc.


### PR DESCRIPTION
Removing the obsolete `times` package and the `notes` option from example files