### PR TITLE
Adding font substitution to fix problem of the new kernel behavior for b/bx font

### DIFF
--- a/base/beamerbasefont.sty
+++ b/base/beamerbasefont.sty
@@ -176,7 +176,7 @@
       <3><4><5><6><7><8><9>cmssbx10%
       <10><10.95><12><14.4><17.28><20.74><24.88><29.86><35.83><42.99><51.59>cmssbx10%
       }{}
-
+\DeclareFontShape{OT1}{cmss}{b}{n}{<->ssub * cmss/bx/n}{}
 
 \newcommand*{\beamer@font@check}{%
   \def\beamer@cmr{cmr}%


### PR DESCRIPTION
Fix #630 following the suggestion of @u-fischer https://chat.stackexchange.com/transcript/41?m=55695847#55695847