### PR TITLE
Fixing hook error for non-shadow rounded themes

### DIFF
--- a/base/beamerbaseboxes.sty
+++ b/base/beamerbaseboxes.sty
@@ -207,7 +207,9 @@
     \vskip2bp%
   \fi%
   \egroup% of \vbox\bgroup
-  \xdef\beamer@colorhook{\beamer@storecolorhook}
+  \ifbmb@shadow%
+    \xdef\beamer@colorhook{\beamer@storecolorhook}
+  \fi
 }
 
 % Shadings


### PR DESCRIPTION
Minimal (non)working example

```
\documentclass{beamer}

\useinnertheme{rounded}

\begin{document}
\begin{frame}
  \begin{block}{title}
  content...
  \end{block}
\end{frame}
\end{document}
```