### PR TITLE
incorrect `\insertmainframenumber` if combined with `ignorenonframetext` fix #665

### DIFF
--- a/base/beamerbasemodes.sty
+++ b/base/beamerbasemodes.sty
@@ -122,6 +122,7 @@
   \ifx\beamer@nexttoken\lecture\let\next=\beamer@stopoutsidemode\fi
   \ifx\beamer@nexttoken\note\let\next=\beamer@stopoutsidemode\fi
   \ifx\beamer@nexttoken\appendix\let\next=\beamer@stopoutsidemode\fi
+  \ifx\beamer@nexttoken\beamer@appendixwrite\let\next=\beamer@stopoutsidemode\fi
   \ifx\beamer@nexttoken\againframe\let\next=\beamer@stopoutsidemode\fi
   \ifx\beamer@nexttoken\section\let\next=\beamer@stopoutsidemode\fi
   \ifx\beamer@nexttoken\subsection\let\next=\beamer@stopoutsidemode\fi

--- a/base/beamerbasesection.sty
+++ b/base/beamerbasesection.sty
@@ -372,13 +372,19 @@
 
 \newcommand<>\beamer@appendix{}
 \def\beamer@resetappendix{\global\let\appendix\beamer@appendix}
-\newcommand<>\appendix{%
-  \beamer@inappendixtrue%
-  \only#1{\part{\appendixname}%
+\def\beamer@appendixwrite{%
   \immediate\write\@auxout{\string\@writefile{nav}%
     {\noexpand\headcommand{\noexpand\gdef\noexpand\insertmainframenumber{\the\c@framenumber}}}}%
   \addtocontents{nav}{\protect\headcommand{\protect\beamer@appendixpages{\the\c@page}}}%
-  \beamer@resetappendix}%
+}
+
+\newcommand<>\appendix{%
+  \beamer@inappendixtrue%
+  \only#1{%
+  \part{\appendixname}%
+  \beamer@appendixwrite%
+  \beamer@resetappendix%
+  }%
 }
 
 \def\insertappendixframenumber{\the\numexpr\inserttotalframenumber-\insertmainframenumber\relax}


### PR DESCRIPTION
Test file:
```
\documentclass[
  ignorenonframetext
]{beamer}

\makeatletter
\newcommand{\foo}{
  \ifbeamer@inappendix%
  	in appendix
  \else%
  	not appendix
  \fi%
}
\makeatother

\begin{document}

\begin{frame}
\insertmainframenumber \foo
\end{frame}

\appendix

\begin{frame}
\insertmainframenumber \foo
\end{frame}

\end{document}
```