### PR TITLE
Patch pdfpages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ a major and minor version only.
 
 - added `aspectratio=2013` class option setting the frames' aspect ratio to 20:13 (see #497)
 - Remove redefinition of `\addtocontents` (see #698)
+- patched macros from the `pdfpages` package to automaticlly remove the frame background for the included pages
 
 ### Fixed
 

--- a/base/beamerbasecompatibility.sty
+++ b/base/beamerbasecompatibility.sty
@@ -70,7 +70,13 @@
         \ifbeamer@ignorenonframe
          \expandafter\mode\expandafter*%
        \fi
-      }
+      }%
+    %
+    % Patching pdfpages package to avoid the included pages from being covered by the background canvas
+    \AddToHook{cmd/includepdf/before}[beamer]{\begingroup\setbeamercolor{background canvas}{bg=}}%
+    \AddToHook{cmd/includepdf/after}[beamer]{\endgroup}%
+    \AddToHook{cmd/includepdfmerge/before}[beamer]{\begingroup\setbeamercolor{background canvas}{bg=}}%
+    \AddToHook{cmd/includepdfmerge/after}[beamer]{\endgroup}%
   }
   {%
     \let\beamer@origdocument\document

--- a/base/beamerbasecompatibility.sty
+++ b/base/beamerbasecompatibility.sty
@@ -57,6 +57,13 @@
     \AddToHook{env/document/begin}[beamer]{\beamer@firstminutepatches}%
     \AddToHook{env/document/begin}[beamer]{%
       \@ifpackageloaded{paralist}{\RequirePackage{beamerpatchparalist}}{}%
+      \@ifpackageloaded{pdfpages}{%
+        % Patching pdfpages package to avoid the included pages from being covered by the background canvas
+        \AddToHook{cmd/includepdf/before}[beamer]{\begingroup\setbeamercolor{background canvas}{bg=}}%
+        \AddToHook{cmd/includepdf/after}[beamer]{\endgroup}%
+        \AddToHook{cmd/includepdfmerge/before}[beamer]{\begingroup\setbeamercolor{background canvas}{bg=}}%
+        \AddToHook{cmd/includepdfmerge/after}[beamer]{\endgroup}%
+      }{}%
     }%
     \AddToHook{begindocument/end}[beamer]%need to be later than spanish.ldf?
       {%
@@ -71,12 +78,6 @@
          \expandafter\mode\expandafter*%
        \fi
       }%
-    %
-    % Patching pdfpages package to avoid the included pages from being covered by the background canvas
-    \AddToHook{cmd/includepdf/before}[beamer]{\begingroup\setbeamercolor{background canvas}{bg=}}%
-    \AddToHook{cmd/includepdf/after}[beamer]{\endgroup}%
-    \AddToHook{cmd/includepdfmerge/before}[beamer]{\begingroup\setbeamercolor{background canvas}{bg=}}%
-    \AddToHook{cmd/includepdfmerge/after}[beamer]{\endgroup}%
   }
   {%
     \let\beamer@origdocument\document

--- a/doc/beamerug-compatibility.tex
+++ b/doc/beamerug-compatibility.tex
@@ -178,31 +178,9 @@ When using certain packages or classes together with the |beamer| class, extra o
 \end{package}
 
 \begin{package}{{pdfpages}}
-  Commands like |\includepdf| only work \emph{outside} frames as they produce pages ``by themselves.'' You may also wish to say
-\begin{verbatim}
-\setbeamercolor{background canvas}{bg=}
-\end{verbatim}
-  when you use such a command since the background (even a white background) will otherwise be printed over the image you try to include.
-
-  \example
-\begin{verbatim}
-\begin{document}
-\begin{frame}
-  \titlepage
-\end{frame}
-
-{
-  \setbeamercolor{background canvas}{bg=}
-  \includepdf{somepdfimages.pdf}
-}
-
-\begin{frame}
-  A normal frame.
-\end{frame}
-\end{document}
-\end{verbatim}
-\end{package}
-
+  Commands like |\includepdf| only work \emph{outside} frames as they produce pages ``by themselves.''
+\end{package}  
+ 
 \begin{package}{{\normalfont\meta{professional font package}}}
   \beamernote
   If you use a professional font package, \beamer's internal redefinition of how variables are typeset may interfere with the font package's superior way of typesetting them. In this case, you should use the class option |professionalfonts| to suppress any font substitution. See Section~\ref{section-substition} for details.


### PR DESCRIPTION
Patching `\includepdf` and `\includepdfmerge` to ensure that the included pages are not hidden behind the background canvas

MWE to test the problem:
```
\documentclass{beamer}

\setbeamercolor{background canvas}{bg=red}
\usepackage{pdfpages}

\begin{document}

\begin{frame}
abc
\end{frame}

\includepdf[pages=1-1]{example-image-duck.pdf}

\begin{frame}
abc
\end{frame}

\includepdfmerge[pages=1-1]{example-image-duck.pdf}

\end{document}
```