### PR TITLE
Replacing class option `notes=onlyslideswithnotes` with beamer option `show only slides with notes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ a major and minor version only.
 - patched macros from the `pdfpages` package to automaticlly remove the frame background for the included pages
 - transparent shadows for smoothbars outer theme (see #717)
 - transparent shadows for smoothtree outer theme (see #720) 
+- added new beamer option "show only slides with notes", the old class option "notes=onlyslideswithnotes" now gives an obsolete warning like all the other note options (see #724)
 
 ### Fixed
 

--- a/base/beamer.cls
+++ b/base/beamer.cls
@@ -188,6 +188,8 @@
   \nofiles
 }
 \def\beamer@notesaction@onlyslideswithnotes{%
+  \ClassWarning{beamer}{This option is obsolete. Use beamer option
+    ``show only slides with notes'' instead.}%
   \beamer@notestrue
   \beamer@frameswithnotesonlytrue
   \nofiles

--- a/base/beamerbasenotes.sty
+++ b/base/beamerbasenotes.sty
@@ -50,7 +50,12 @@
   \nofiles
 }
 
-
+\defbeameroption{show only slides with notes}[]%
+{
+  \beamer@notestrue
+  \beamer@frameswithnotesonlytrue
+  \nofiles
+}
 
 %
 % Notes

--- a/doc/beamerug-notes.tex
+++ b/doc/beamerug-notes.tex
@@ -218,5 +218,5 @@ Since you normally do not wish the notes to be part of your presentation, you mu
 \end{beameroption}
 
 \begin{beameroption}{show only slides with notes}{}
-  Include only slides in the output file, which have an accompanying note page. Slides without notes will be excluded. If you specify this command, the |.aux| and |.toc| files are \emph{not} updated. So, if you add a section and re\TeX\ your presentation, this will not be reflected in the navigation bars.
+  Include only slides in the output file that have an accompanying note page. Slides without notes will be excluded. If you specify this command, the |.aux| and |.toc| files are \emph{not} updated. So, if you add a section and re\TeX\ your presentation, this will not be reflected in the navigation bars.
 \end{beameroption}

--- a/doc/beamerug-notes.tex
+++ b/doc/beamerug-notes.tex
@@ -17,7 +17,7 @@ A \emph{note} is text that is intended as a reminder to yourself of what you sho
 
 \subsection{Specifying Note Contents}
 
-To add a note to a slide or a frame, use the |\note| command. This command can be used both inside and outside frames, but it has quite different behaviors then: Inside frames, |\note| commands accumulate and append a single note page after the current slide; outside frames each |\note| directly inserts a single note page with the given parameter as contents. Using the |\note| command inside frames is usually preferably over using them outside, since only commands issued inside frames profit from the class option |onlyslideswithnotes|, see below.
+To add a note to a slide or a frame, use the |\note| command. This command can be used both inside and outside frames, but it has quite different behaviors then: Inside frames, |\note| commands accumulate and append a single note page after the current slide; outside frames each |\note| directly inserts a single note page with the given parameter as contents. Using the |\note| command inside frames is usually preferably over using them outside, since only commands issued inside frames profit from the class option |notes=onlyslideswithnotes|.
 
 Inside a frame, the effect of |\note|\meta{text} is the following: When you use it somewhere inside the frame on a specific slide, a note page is created after the slide, containing the \meta{text}. Since you can add an overlay specification to the |\note| command, you can specify after which slide the note should be shown. If you use multiple |\note| commands on one slide, they ``accumulate'' and are all shown on the same note.
 
@@ -61,7 +61,7 @@ In the following, the syntax and effects of the |\note| command \emph{inside} fr
 Next, the syntax and effects of the |\note| command \emph{outside} frames are described:
 
 \begin{command}{\note\oarg{options}\marg{note text}}
-  Outside frames, this command creates a note page. This command is \emph{not} affected by the option |notes=onlyframeswithnotes|, see below.
+  Outside frames, this command creates a note page. This command is \emph{not} affected by the option |notes=onlyslideswithnotes|.
 
   The following \meta{options} may be given:
   \begin{itemize}

--- a/doc/beamerug-notes.tex
+++ b/doc/beamerug-notes.tex
@@ -17,7 +17,7 @@ A \emph{note} is text that is intended as a reminder to yourself of what you sho
 
 \subsection{Specifying Note Contents}
 
-To add a note to a slide or a frame, use the |\note| command. This command can be used both inside and outside frames, but it has quite different behaviors then: Inside frames, |\note| commands accumulate and append a single note page after the current slide; outside frames each |\note| directly inserts a single note page with the given parameter as contents. Using the |\note| command inside frames is usually preferably over using them outside, since only commands issued inside frames profit from the class option |notes=onlyslideswithnotes|.
+To add a note to a slide or a frame, use the |\note| command. This command can be used both inside and outside frames, but it has quite different behaviors then: Inside frames, |\note| commands accumulate and append a single note page after the current slide; outside frames each |\note| directly inserts a single note page with the given parameter as contents. Using the |\note| command inside frames is usually preferably over using them outside, since only commands issued inside frames profit from the option |show only slides with notes|.
 
 Inside a frame, the effect of |\note|\meta{text} is the following: When you use it somewhere inside the frame on a specific slide, a note page is created after the slide, containing the \meta{text}. Since you can add an overlay specification to the |\note| command, you can specify after which slide the note should be shown. If you use multiple |\note| commands on one slide, they ``accumulate'' and are all shown on the same note.
 
@@ -61,7 +61,7 @@ In the following, the syntax and effects of the |\note| command \emph{inside} fr
 Next, the syntax and effects of the |\note| command \emph{outside} frames are described:
 
 \begin{command}{\note\oarg{options}\marg{note text}}
-  Outside frames, this command creates a note page. This command is \emph{not} affected by the option |notes=onlyslideswithnotes|.
+  Outside frames, this command creates a note page. This command is \emph{not} affected by the option |show only slides with notes|.
 
   The following \meta{options} may be given:
   \begin{itemize}
@@ -213,7 +213,10 @@ Since you normally do not wish the notes to be part of your presentation, you mu
 \end{verbatim}
 \end{beameroption}
 
-
 \begin{beameroption}{show only notes}{}
   Include only the notes in the output file and suppresses all frames. This options is useful for printing them. If you specify this command, the |.aux| and |.toc| files are \emph{not} updated. So, if you add a section and re\TeX\ your presentation, this will not be reflected in the navigation bars (which you do not see anyway since only notes are output).
+\end{beameroption}
+
+\begin{beameroption}{show only slides with notes}{}
+  Include only slides in the output file, which have an accompanying note page. Slides without notes will be excluded. If you specify this command, the |.aux| and |.toc| files are \emph{not} updated. So, if you add a section and re\TeX\ your presentation, this will not be reflected in the navigation bars.
 \end{beameroption}


### PR DESCRIPTION
- adding new `show only slides with notes` beamer option 
- raising a warning if `notes=onlyslideswithnotes` class option is used (like all other `notes=...` options already do for a decade)
- documenting new option in doc (old class option was mostly undocumented)

(close #724)

Test file:

```
\documentclass[
%notes=onlyslideswithnotes
]{beamer}

\setbeameroption{show only slides with notes}

\begin{document}
	
\begin{frame}
	slide without note\pause
  
  slide with note 
  \note<2>{note text}
\end{frame}	

\end{document}
```
