### PR TITLE
Adding `onlytextwidth` class option (close #731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a major and minor version only.
 
 ## [Unreleased]
 
+### Added
+
+- adding new `onlytextwidth` class option to use this key for all `columns` environments by default (see #731)
+
 ### Fixed
 
 - using `gray` colormodel for the delcarartion of fadings (workaround for #718)

--- a/base/beamer.cls
+++ b/base/beamer.cls
@@ -88,6 +88,7 @@
 \newif\ifbeamer@frameswithnotesonly
 \newif\ifbeamer@ignorenonframe
 \newif\ifbeamer@autopdfinfo
+\newif\ifbeamer@onlytextwidth
 
 % Option management
 \RequirePackage{beamerbaseoptions}
@@ -107,6 +108,7 @@
 \beamer@frameswithnotesonlyfalse
 \beamer@ignorenonframefalse
 \beamer@autopdfinfotrue
+\beamer@onlytextwidthfalse
 
 \DeclareOptionBeamer{usepdftitle}[true]{\csname beamer@autopdfinfo#1\endcsname}
 \DeclareOptionBeamer{envcountsect}{\beamer@countsecttrue}
@@ -169,6 +171,8 @@
       \lccode`\~=\count@
       \catcode\count@=\active
       \lowercase{\def~{\kern1ex}}}}}
+      
+\DeclareOptionBeamer{onlytextwidth}{\beamer@onlytextwidthtrue}      
 
 % obsolete options
 \DeclareOptionBeamer{notes}[show]{\csname beamer@notesaction@#1\endcsname}

--- a/base/beamerbaseframecomponents.sty
+++ b/base/beamerbaseframecomponents.sty
@@ -205,19 +205,24 @@
 
 \newenvironment<>{columns}[1][]{%
   \begin{actionenv}#2%
-  \def\beamer@colentrycode{%
-    \hbox to\textwidth\bgroup%
-    \leavevmode%
-    \hskip-\beamer@leftmargin%
-    \nobreak%
-    \beamer@tempdim=\textwidth%
-    \advance\beamer@tempdim by\beamer@leftmargin%
-    \advance\beamer@tempdim by\beamer@rightmargin%
-    \hbox to\beamer@tempdim\bgroup%
-    \hbox{}\hfill\ignorespaces}%
-  \def\beamer@colexitcode{\egroup%
-    \nobreak%
-    \hskip-\beamer@rightmargin\egroup}%
+  \ifbeamer@onlytextwidth
+    \def\beamer@colentrycode{\hbox to\textwidth\bgroup\ignorespaces}%
+    \def\beamer@colexitcode{\unskip\egroup}
+  \else%
+    \def\beamer@colentrycode{%
+      \hbox to\textwidth\bgroup%
+      \leavevmode%
+      \hskip-\beamer@leftmargin%
+      \nobreak%
+      \beamer@tempdim=\textwidth%
+      \advance\beamer@tempdim by\beamer@leftmargin%
+      \advance\beamer@tempdim by\beamer@rightmargin%
+      \hbox to\beamer@tempdim\bgroup%
+      \hbox{}\hfill\ignorespaces}%
+    \def\beamer@colexitcode{\egroup%
+      \nobreak%
+      \hskip-\beamer@rightmargin\egroup}%
+  \fi%
   \ifbeamer@centered\setkeys{beamer@col}{c}\else\setkeys{beamer@col}{t}\fi%
   \setkeys{beamer@col}{#1}%
   \par%

--- a/doc/beamerug-localstructure.tex
+++ b/doc/beamerug-localstructure.tex
@@ -948,7 +948,9 @@ The main environment for creating columns is called |columns|. Inside this envir
   \item
     \declare{|c|} will cause the columns to be centered vertically relative to each other. Default, unless the global option |t| is used.
   \item
-    \declare{|onlytextwidth|} is the same as |totalwidth=\textwidth|.
+    \declare{|onlytextwidth|} is the same as |totalwidth=\textwidth|. This option can also be set for the whole document with the |onlytextwidth| class option:
+    \begin{classoption}{onlytextwidth}
+    \end{classoption}
   \item
     \declare{|t|} will cause the first lines of the columns to be aligned. Default if global option |t| is used.
   \item


### PR DESCRIPTION
With this new class option, the `onlytextwidth` key will be used for all `columns` environments