### PR TITLE
Making miniframes clickable in xelatex (workaround #332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ a major and minor version only.
 
 - using `gray` colormodel for the delcarartion of fadings (workaround for #718)
 - fixed bullet colour of alerted items for custom item colour (see #735)
+- workaround to make miniframes clickable in xelatex (see #332)
 
 ## [v3.64]
 

--- a/base/themes/outer/beamerouterthemedefault.sty
+++ b/base/themes/outer/beamerouterthemedefault.sty
@@ -18,11 +18,21 @@
   {mini frame,mini frame in current section,mini frame in current subsection}
 {}
 
+\newcommand{\beamer@xelatex@fixminiframes}{%
+  \expandafter\ifx\csname XeTeXrevision\endcsname\relax
+  \else
+    \pgfsetfillopacity{0}
+    \pgftext[x=0cm,y=0.0cm]{\color{green}.}
+    \pgftext[x=0.1cm,y=0.1cm]{\color{green}.}    
+  \fi
+}
+
 \defbeamertemplate*{mini frame}{default}
 {%
   \begin{pgfpicture}{0pt}{0pt}{0.1cm}{0.1cm}
     \pgfpathcircle{\pgfpoint{0.05cm}{0.05cm}}{0.05cm}
     \pgfusepath{fill,stroke}
+    \beamer@xelatex@fixminiframes
   \end{pgfpicture}%
 }
 [action]
@@ -35,6 +45,7 @@
   \begin{pgfpicture}{0pt}{0pt}{0.1cm}{0.1cm}
     \pgfpathcircle{\pgfpoint{0.05cm}{0.05cm}}{0.05cm}
     \pgfusepath{stroke}
+    \beamer@xelatex@fixminiframes
   \end{pgfpicture}%
 }
 
@@ -43,6 +54,7 @@
   \begin{pgfpicture}{0pt}{0pt}{0.1cm}{0.1cm}
     \pgfpathcircle{\pgfpoint{0.05cm}{0.05cm}}{0.05cm}
     \pgfusepath{stroke}
+    \beamer@xelatex@fixminiframes
   \end{pgfpicture}%
 }
 


### PR DESCRIPTION
Using the same trick as in https://github.com/josephwright/beamer/blob/620462b6f3820d88c563e00a2dfdc9abade4d343/base/beamerbasenavigation.sty#L217-L219