### PR TITLE
Adapt slide transitions to pdfmanagement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a major and minor version only.
 
 ## [Unreleased]
 
+### Fixed
+- slide transitions if the new pdfmanagement is used
+- name of transition replace in pdf is R not Replace
+
 ## [v3.66]
 
 ### Fixed

--- a/base/beamerbaseoverlay.sty
+++ b/base/beamerbaseoverlay.sty
@@ -741,6 +741,7 @@
   \edef\beamer@temp{{pdfpagetransition={#2 \beamer@transdir\space\beamer@dur}}}%
   \expandafter\hypersetup\beamer@temp}
 
+
 \mode
 <article>
 {
@@ -770,6 +771,27 @@
 }
 
 \newcommand<>{\transduration}[1]{\only#2{\hypersetup{pdfpageduration={#1}}}}
+
+\@ifundefined{IfPDFManagementActiveTF}{}
+ {
+  \IfPDFManagementActiveTF
+   {
+     \renewcommand\beamer@dotrans[2][]{%
+           \hypersetup{pdfpagetransition={style=#2,#1}}%
+     }
+     \renewcommand<>{\transblindshorizontal}[1][]{\only#2{\beamer@dotrans[{#1,direction=H}]{Blinds}}}
+     \renewcommand<>{\transblindsvertical}[1][]{\only#2{\beamer@dotrans[{#1,direction=V}]{Blinds}}}
+     \renewcommand<>{\transboxin}[1][]{\only#2{\beamer@dotrans[{#1,motion=I}]{Box}}}
+     \renewcommand<>{\transboxout}[1][]{\only#2{\beamer@dotrans[{#1,motion=O}]{Box}}}
+     \renewcommand<>{\transsplitverticalin}[1][]{\only#2{\beamer@dotrans[{#1,direction=V,motion=I}]{Split}}}
+     \renewcommand<>{\transsplitverticalout}[1][]{\only#2{\beamer@dotrans[{#1,direction=V,motion=O}]{Split}}}
+     \renewcommand<>{\transsplithorizontalin}[1][]{\only#2{\beamer@dotrans[{#1,direction=H,motion=I}]{Split}}}
+     \renewcommand<>{\transsplithorizontalout}[1][]{\only#2{\beamer@dotrans[{#1,direction=H,motion=O}]{Split}}}
+     \renewcommand<>{\transreplace}[1][]{\only#2{\beamer@dotrans[{#1}]{R}}}
+   }
+   {}
+ }
+
 
 \mode
 <article>

--- a/base/beamerbaseoverlay.sty
+++ b/base/beamerbaseoverlay.sty
@@ -760,7 +760,7 @@
   \newcommand<>{\transfade}[1][]{\only#2{\beamer@dotrans[{#1}]{Fade}}}
   \newcommand<>{\transglitter}[1][]{\only#2{\beamer@dotrans[{#1}]{Glitter}}}
   \newcommand<>{\transpush}[1][]{\only#2{\beamer@dotrans[{#1}]{Push}}}
-  \newcommand<>{\transreplace}[1][]{\only#2{\beamer@dotrans[{#1}]{Replace}}}
+  \newcommand<>{\transreplace}[1][]{\only#2{\beamer@dotrans[{#1}]{R}}}
   \newcommand<>{\transsplitverticalin}[1][]{\only#2{\beamer@dotrans[{#1}]{Split /Dm /V /M /I}}}
   \newcommand<>{\transsplitverticalout}[1][]{\only#2{\beamer@dotrans[{#1}]{Split /Dm /V /M /O}}}
   \newcommand<>{\transsplithorizontalin}[1][]{\only#2{\beamer@dotrans[{#1}]{Split /Dm /H /M /I}}}


### PR DESCRIPTION
The new hyperref driver used with the pdfmanagement changed and extended the syntax of the `pdfpagetransition` key, it now expects a key-value list.  As reported here https://github.com/latex3/pdfresources/issues/29  this lead to errors in beamer.

The pull request changes the beamer code to the new hyperref syntax if the pdfmanagement is active.
It also corrects also a small error in the original code.

The following can be used to test the transitions:
Some of the transitions require currently the develop branch of the pdfresources as there was a typo in the `direction` implementation in the hyperref driver.


~~~~
\RequirePackage{pdfmanagement-testphase}
\DocumentMetadata{} %comment to deactivate the pdfmanagement.

\documentclass{beamer}
\usepackage{tikzlings}
\begin{document}
\begin{frame}

blub

\end{frame}

\begin{frame}
\transblindshorizontal[duration=1]
blinds horizontal

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transblindsvertical[duration=1]
blinds vertical

\tikz[scale=3]{\marmot} \tikz[scale=3]{\sloth}

\end{frame}

\begin{frame}
\transboxin[duration=1]
box in

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transboxout[duration=1]
box out

\tikz[scale=3]{\marmot} \tikz[scale=3]{\sloth}

\end{frame}

\begin{frame}
\transcover[duration=1]
cover

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transcover[duration=1,direction=270]
cover 270

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transdissolve[duration=1]
dissolve
\tikz[scale=3]{\marmot} \tikz[scale=3]{\sloth}


\end{frame}

\begin{frame}
\transfade[duration=10]
fade

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transglitter[duration=10]
glitter

\tikz[scale=3]{\marmot} \tikz[scale=3]{\sloth}

\end{frame}

\begin{frame}
\transpush[duration=1]
push

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transreplace[duration=1]
replace

\tikz[scale=3]{\marmot} \tikz[scale=3]{\sloth}

\end{frame}

\begin{frame}
\transsplitverticalin[duration=1]
vertical in

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transsplitverticalout[duration=1]
vertical out

\tikz[scale=3]{\marmot} \tikz[scale=3]{\sloth}

\end{frame}

\begin{frame}
\transsplithorizontalin[duration=1]
horizontal in

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transsplithorizontalout[duration=1]
horizontal out

\tikz[scale=3]{\marmot} \tikz[scale=3]{\sloth}

\end{frame}

\begin{frame}
\transuncover[duration=1]
uncover

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transwipe[duration=1]
wipe

\tikz[scale=3]{\marmot} \tikz[scale=3]{\sloth}

\end{frame}

\begin{frame}
\transfly[duration=1,direction=90]
fly 90

\tikz[scale=3]{\bear} \tikz[scale=3]{\rhino}

\end{frame}

\begin{frame}
\transfly[duration=1,direction=180]
fly 180

\tikz[scale=3]{\marmot} \tikz[scale=3]{\sloth}

\end{frame}

\end{document}
~~~~ 
