### PR TITLE
Enables `\includeslide` in presentation mode too

### DIFF
--- a/base/beamerarticle.sty
+++ b/base/beamerarticle.sty
@@ -30,7 +30,6 @@
 
 \ProcessOptions\relax
 
-\def\beamer@slide#1#2{\expandafter\gdef\csname beamer@slide#1\endcsname{#2}}
 \beamer@inpresentationfalse
 
 \ifx\beamer@currentmode\@undefined

--- a/base/beamerbasemodes.sty
+++ b/base/beamerbasemodes.sty
@@ -239,13 +239,22 @@
   \ifx\jobnamebeamerversion\@empty
     \ClassError{beamer}{Invoke macro "setjobnamebeamerversion" first}\@ehc
   \else
-    \edef\beamer@args
-      {[{#1,page=\csname beamer@slide#2\endcsname}]{\jobnamebeamerversion}}%
-    \expandafter\pgfimage\beamer@args
+    \ifcsname beamer@slide#2\endcsname%
+      \edef\beamer@args
+        {[{#1,page=\csname beamer@slide#2\endcsname}]{\jobnamebeamerversion}}%
+      \expandafter\pgfimage\beamer@args
+    \else
+      \ClassWarning{beamer}{ref #2 doesn't exist (yet),
+        requires \jobnamebeamerversion.snm}
+      \texttt{[slide #2]}
+    \fi
   \fi}
 
 \newrobustcmd*\setjobnamebeamerversion[1]{%
   \gdef\jobnamebeamerversion{#1}%
+  \def\beamer@slide##1##2{%
+    \message{( beamer@slide ##1 ##2 )}%
+    \expandafter\gdef\csname beamer@slide##1\endcsname{##2}}%
   \begingroup
     \makeatletter
     \@input{\jobnamebeamerversion.snm}%


### PR DESCRIPTION
Seemingly this didn't work due to `\beamer@slides` being defined only in
`beamerarticle.sty`. However, it didn't work to just move it to
`beamerbasemodes.sty`. I had to put it into `\setjobnamebeamerversion`,
so it was defined just before the `\@input`. Not sure why.

This also adds some log output, a warning and a placeholder when the
designated slide reference isn't loaded. The current error when this
doesn't work is a very unhelpful "missing number, treated as zero".

We need the warning instead of error to include slides from the current
slide deck, since we don't want to cause errors building the first
version required for the real version. Example:

File `slides.tex`:
```LaTeX
\documentclass{beamer}
\setjobnamebeamerversion{slides-incomplete}

\begin{document}
  \begin{frame}\label{first}
    the first frame
  \end{frame}

  \begin{frame}
    \begin{figure}
      \includeslide[width=0.5\columnwidth]{first}
      \caption{An example slide from earlier}
    \end{figure}
  \end{frame}
\end{document}
```

Then we can build like this:
```
pdflatex slides
mv slides.pdf slides-incomplete.pdf
mv slides.snm slides-incomplete.snm
pdflatex slides
```

Comments welcome!