### PR TITLE
move nameref patches to beamer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ a major and minor version only.
 
 ## [Unreleased]
 
+### Changed
+- beamer sets \@currentlabelname itself and no longer relies on nameref patches.
+
 ### Fixed
 - slide transitions if the new pdfmanagement is used
 - name of transition replace in pdf is R not Replace

--- a/base/beamer.cls
+++ b/base/beamer.cls
@@ -171,8 +171,8 @@
       \lccode`\~=\count@
       \catcode\count@=\active
       \lowercase{\def~{\kern1ex}}}}}
-      
-\DeclareOptionBeamer{onlytextwidth}{\beamer@onlytextwidthtrue}      
+
+\DeclareOptionBeamer{onlytextwidth}{\beamer@onlytextwidthtrue}
 
 % obsolete options
 \DeclareOptionBeamer{notes}[show]{\csname beamer@notesaction@#1\endcsname}
@@ -274,7 +274,7 @@
       \AtBeginDocument{\PreloadUnicodePage{0}}%
       \AtBeginDocument{\PreloadUnicodePage{1}}%
     }
-  \else    
+  \else
     \def\beamer@loaducs{%
       \RequirePackage{ucs}%
       \AtBeginDocument{\PreloadUnicodePage{0}}%
@@ -368,7 +368,8 @@
 
 % Normally loaded by hyperref but to be on the safe side ...
 \RequirePackage{atbegshi}
-
+% suppress the nameref beamer patches as they are now done by beamer:
+\def\NR@nopatch@beamer{}
 \RequirePackage[implicit=false]{hyperref}
 
 \hypersetup{pdfcreator={LaTeX with Beamer class}}

--- a/base/beamerbaseauxtemplates.sty
+++ b/base/beamerbaseauxtemplates.sty
@@ -190,8 +190,8 @@
   % prevents the period to be printed with the first/last section option
   \ifnum\beamer@tempcount>\beamer@toclastsection
   \else
-  \ifnum\beamer@tempcount>0 
-    \inserttocsectionnumber. 
+  \ifnum\beamer@tempcount>0
+    \inserttocsectionnumber.
   \fi\fi%
   \inserttocsection\par%
 }
@@ -854,7 +854,12 @@
 \defbeamertemplate{theorem end}{numbered}
 {\end{\inserttheoremblockenv}}
 
-
+\AtBeginDocument{%
+  \addtobeamertemplate{theorem begin}{%
+     \expandafter\GetTitleString\expandafter{\inserttheoremaddition}%
+     \let\@currentlabelname\GetTitleStringResult}{}%
+ }
+ 
 \defbeamertemplate{theorem begin}{normal font}
 {
   \normalfont

--- a/base/beamerbaselocalstructure.sty
+++ b/base/beamerbaselocalstructure.sty
@@ -305,6 +305,8 @@
 \def\enddescription{\ifhmode\unskip\fi\endlist%
   \usebeamertemplate{description body end}}
 \long\def\beamer@descriptionitem#1{%
+  \GetTitleString{#1}%
+  \let\@currentlabelname\GetTitleStringResult
   \def\insertdescriptionitem{#1}%
   \hfil\hspace\labelsep{\usebeamertemplate**{description item}}}
 
@@ -495,12 +497,12 @@
        {\ifcsundef{abx@field@title}{}{\ifpunct{}{\midsentence\newunitpunct}}%
         \newblock\unspace\usebeamercolor[fg]{bibliography entry note}}{}{}}
     {}}
-    
+
 % Adding patches to some biblatex styles
 \csappto{blx@filehook@postload@numeric.bbx}{%
   \mode<presentation>{\setbeamertemplate{bibliography item}{\insertbiblabel}}}
 \csappto{blx@filehook@postload@alphabetic.bbx}{%
-  \mode<presentation>{\setbeamertemplate{bibliography item}{\insertbiblabel}}}  
+  \mode<presentation>{\setbeamertemplate{bibliography item}{\insertbiblabel}}}
 \csappto{blx@filehook@postload@authoryear.bbx}{%
   \mode<presentation>{%
     \pretocmd{\bibsetup}{%
@@ -509,7 +511,7 @@
       \addtolength{\labelwidth}{2\labelsep}%
       \addtolength{\bibhang}{\labelsep}%
     }{}{}%
-  }}  
+  }}
 \csappto{blx@filehook@postload@authortitle.bbx}{%
   \mode<presentation>{%
     \pretocmd{\bibsetup}{%

--- a/base/beamerbasesection.sty
+++ b/base/beamerbasesection.sty
@@ -178,6 +178,8 @@
 \long\def\beamer@@ssection*#1{\beamer@section[{#1}]{}}
 \long\def\beamer@@@section#1{\beamer@section[{#1}]{#1}}
 \long\def\beamer@section[#1]#2{%
+  \GetTitleString{#1}%
+  \let\@currentlabelname\GetTitleStringResult
   \beamer@savemode%
   \mode<all>%
   \ifbeamer@inlecture
@@ -202,7 +204,7 @@
     \def\insertsubsection{}%
     \def\insertsubsubsection{}%
     % Deal with a defective patch in metropolis theme
-    \def\insertsectionhead{\hyperlink{Navigation\the\c@page}{#1}}% 
+    \def\insertsectionhead{\hyperlink{Navigation\the\c@page}{#1}}%
     \edef\insertsectionhead{\noexpand\hyperlink{Navigation\the\c@page}{\unexpanded{#1}}}%
     \def\insertsubsectionhead{}%
     \def\insertsubsubsectionhead{}%
@@ -254,6 +256,8 @@
 \long\def\beamer@@ssubsection*#1{\beamer@subsection[{#1}]{}}
 \def\beamer@@@subsection#1{\beamer@subsection[{#1}]{#1}}
 \def\beamer@subsection[#1]#2{%
+  \GetTitleString{#1}%
+  \let\@currentlabelname\GetTitleStringResult
   \beamer@savemode%
   \mode<all>%
   \ifbeamer@inlecture%
@@ -319,6 +323,8 @@
 \long\def\beamer@@ssubsubsection*#1{\beamer@subsubsection[{#1}]{}}
 \def\beamer@@@subsubsection#1{\beamer@subsubsection[{#1}]{#1}}
 \def\beamer@subsubsection[#1]#2{%
+  \GetTitleString{#1}%
+  \let\@currentlabelname\GetTitleStringResult
   \beamer@savemode%
   \mode<all>%
   \ifbeamer@inlecture%


### PR DESCRIPTION
This moves the patches of beamer made by nameref.  `nameref` only wants the `\@currentlabelname` is define suitable for a \label.  `\def\NR@nopatch@beamer{}` suppresses the patches in nameref. 

