### PR TITLE
replace verse with center in example for \renewcommand

### DIFF
--- a/doc/beamerug-overlays.tex
+++ b/doc/beamerug-overlays.tex
@@ -539,9 +539,9 @@ This section explains how to define new commands that are overlay specification-
 
   \example
 \begin{verbatim}
-\renewenvironment<>{verse}
-{\begin{actionenv}#1\begin{originalverse}}
-{\end{originalverse}\end{actionenv}}
+\renewenvironment<>{center}
+    {\begin{actionenv}#1\begin{originalcenter}}
+    {\end{originalcenter}\end{actionenv}}
 \end{verbatim}
 \end{command}
 


### PR DESCRIPTION
verse is actually already redefined by beamer, so this example would result in an error