### PR TITLE
protect the frametitle continuation with \CaseSwitch so it can be used with \MakeUppercase (fix #802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ a major and minor version only.
 
 ### Fixed
 
-- protect the frametitle continuation with \CaseSwitch so it can be used with \MakeUppercase (see #802)
+- protect the frametitle continuation so it can be used with \MakeUppercase (see #802)
 
 ## [v3.68]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a major and minor version only.
 
 ## [Unreleased]
 
+### Fixed
+
+- protect the frametitle continuation with \CaseSwitch so it can be used with \MakeUppercase (see #802)
+
 ## [v3.68]
 
 ### Changed

--- a/base/beamerbaselocalstructure.sty
+++ b/base/beamerbaselocalstructure.sty
@@ -22,17 +22,16 @@
 % The \frametitle command
 %
 %
+\protected\def\beamer@insertframetitlecontinuation{\usebeamertemplate*{frametitle continuation}}
+
 \newcommand<>\frametitle{\alt#1{\@dblarg\beamer@@frametitle}{\beamer@gobbleoptional}}
 \long\def\beamer@@frametitle[#1]#2{%
   \ifblank{#2}{}{%
     \gdef\insertframetitle{{%
       #2%
       \ifnum\beamer@autobreakcount>0
-        \relax{}\space
-        \CaseSwitch{\usebeamertemplate*{frametitle continuation}}
-          {\usebeamertemplate*{frametitle continuation}}
-          {\usebeamertemplate*{frametitle continuation}}
-          {\usebeamertemplate*{frametitle continuation}}%
+        \relax{}\space%
+        \beamer@insertframetitlecontinuation%
       \fi%
     }}%
   \gdef\beamer@frametitle{#2}%

--- a/base/beamerbaselocalstructure.sty
+++ b/base/beamerbaselocalstructure.sty
@@ -25,10 +25,19 @@
 \newcommand<>\frametitle{\alt#1{\@dblarg\beamer@@frametitle}{\beamer@gobbleoptional}}
 \long\def\beamer@@frametitle[#1]#2{%
   \ifblank{#2}{}{%
-    \gdef\insertframetitle{{#2\ifnum\beamer@autobreakcount>0\relax{}\space\usebeamertemplate*{frametitle continuation}\fi}}%
+    \gdef\insertframetitle{{%
+      #2%
+      \ifnum\beamer@autobreakcount>0
+        \relax{}\space
+        \CaseSwitch{\usebeamertemplate*{frametitle continuation}}
+          {\usebeamertemplate*{frametitle continuation}}
+          {\usebeamertemplate*{frametitle continuation}}
+          {\usebeamertemplate*{frametitle continuation}}%
+      \fi%
+    }}%
   \gdef\beamer@frametitle{#2}%
   \gdef\beamer@shortframetitle{#1}%
-}%
+  }%
 }
 
 \newcommand\insertshortframetitle[1][]{%


### PR DESCRIPTION
Adding [u-fischer](https://github.com/u-fischer)'s fix for https://github.com/josephwright/beamer/issues/802