### PR TITLE
moved shading a bit down in smoothbars outer theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a major and minor version only.
 
 ## [Unreleased]
 
+### Changed
+
+- smoothbars outer theme: moved the shading between headline and frametitle a bit down to avoid the miniframe appearing clipped off in some pdf viewers
+
 ## [v3.69]
 
 ### Fixed

--- a/base/themes/outer/beamerouterthemesmoothbars.sty
+++ b/base/themes/outer/beamerouterthemesmoothbars.sty
@@ -99,6 +99,7 @@
       leftskip=.3cm,rightskip=.3cm plus1fil]{subsection in head/foot}
       \usebeamerfont{subsection in head/foot}\insertsubsectionhead
     \end{beamercolorbox}%
+    \vskip-0.1ex%
   \fi%
 }%
 
@@ -106,12 +107,12 @@
 \defbeamertemplate*{frametitle}{smoothbars theme}
 {%
   \nointerlineskip%
-  \vskip-0.19ex%
+  \vskip-0.1ex%
   \usebeamerfont{headline}%
   \begin{beamercolorbox}[wd=\paperwidth,ht=1ex,dp=1ex,vmode]{empty}
     \pgfuseshading{beamer@aboveframetitle}%
   \end{beamercolorbox}%
-  \vskip-1ex%
+  \vskip-1.09ex%
   \nointerlineskip%
   \begin{beamercolorbox}[wd=\paperwidth,leftskip=.3cm,rightskip=.3cm plus1fil,vmode]{frametitle}
     \vskip0.5ex%


### PR DESCRIPTION
to avoid the miniframes from appearing clipped of in some pdf viewers