### PR TITLE
scale height of infolines headline with fontsize of `section in head/foot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ a major and minor version only.
 ### Changed
 
 - smoothbars outer theme: moved the shading between headline and frametitle a bit down to avoid the miniframe appearing clipped off in some pdf viewers
-
 - made top shading of Singapore theme transparent (see #782)
+- scale height of infolines headline with fontsize of `section in head/foot`
 
 ### Fixed
 

--- a/base/themes/outer/beamerouterthemeinfolines.sty
+++ b/base/themes/outer/beamerouterthemeinfolines.sty
@@ -47,11 +47,12 @@
 {%
   \leavevmode%
   \hbox{%
+  \usebeamerfont{section in head/foot}%
   \begin{beamercolorbox}[wd=.5\paperwidth,ht=2.65ex,dp=1.5ex,right]{section in head/foot}%
-    \usebeamerfont{section in head/foot}\insertsectionhead\hspace*{2ex}
+    \usebeamerfont{headline}\usebeamerfont{section in head/foot}\insertsectionhead\hspace*{2ex}
   \end{beamercolorbox}%
   \begin{beamercolorbox}[wd=.5\paperwidth,ht=2.65ex,dp=1.5ex,left]{subsection in head/foot}%
-    \usebeamerfont{subsection in head/foot}\hspace*{2ex}\insertsubsectionhead
+    \usebeamerfont{headline}\usebeamerfont{subsection in head/foot}\hspace*{2ex}\insertsubsectionhead
   \end{beamercolorbox}}%
   \vskip0pt%
 }


### PR DESCRIPTION
As shown in https://tex.stackexchange.com/q/678971/36296 the infolines headline can get too small if users choose a bigger `(sub)section in head/foot` font. Currently the height of the boxes is defined relative the `headline` font (which has `tiny structure` as parent font). 

One could lessen the problem by scaling it with respect to the `section in head/foot` font. 

Cons:

- for existing presentations with a non-standard `section in head/foot` font, this will change the layout
- I'm making the assumption that the `section in head/foot` font is bigger or equal to the `subsection in head/foot` font. In case the `subsection in head/foot` font is bigger than the `section in head/foot` font one will still have this problem.

Test file: 

```
\documentclass[compress]{beamer}
\usetheme{CambridgeUS}

\setbeamerfont{section in head/foot}{size=\fontsize{15}{15}\selectfont}
\setbeamerfont{subsection in head/foot}{size=\fontsize{15}{15}\selectfont}

\begin{document}

\section{Title Page}
\subsection{XXXXXXXXXXXXXXXXXXXXXXXX}
\begin{frame}
\frametitle{title}
\title{Estimation}
\titlepage
\end{frame}

\end{document}
```