### PR TITLE
calculate the head/footheight at the start of each frame instead of only at the start of the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ a major and minor version only.
 
 - smoothbars outer theme: moved the shading between headline and frametitle a bit down to avoid the miniframe appearing clipped off in some pdf viewers
 - made top shading of Singapore theme transparent (see #782)
+- calculate the head/footheight at the start of each frame instead of only at the start of the document
 
 ### Fixed
 

--- a/base/beamerbaseframe.sty
+++ b/base/beamerbaseframe.sty
@@ -2,7 +2,7 @@
 % Copyright 2010 by Vedran Mileti\'c
 % Copyright 2011--2015 by Vedran Mileti\'c, Joseph Wright
 % Copyright 2017,2018 by Louis Stuart, Joseph Wright
-% Copyright 2020,2022 by Joseph Wright, samcarter
+% Copyright 2020,2022,2023 by Joseph Wright, samcarter
 %
 % This file may be distributed and/or modified
 %
@@ -419,6 +419,7 @@
   \@ifnextchar[{\beamer@@@frame<#1>}{\beamer@@@frame<#1>[]}}
 \def\beamer@@@frame<#1>[{\@ifnextchar<{\beamer@framedefaultospec<#1>[}{\beamer@@@@frame<#1>[}}
 \def\beamer@@@@frame<#1>[#2]{%
+  \beamer@calculateheadfoot
   \framewidth\textwidth
   \beamer@savemode%
   \gdef\beamer@mode{\mode<all>}%


### PR DESCRIPTION
Currently beamer calculates the head/footheight at the start of the document. This makes it complicate to change the height of these elements during the presentation (e.g. if title/section pages should have a taller headline).

One could avoid this problem by calculating head/footheight at the start of each frame. 

The disadvantage of this approach is performance. For example a test document with about 100 frames takes

- 2.29 seconds with calculating at the start of the document only
- 2.55 seconds with calculating on every frame

Test document:

```
\documentclass{beamer}

\usepackage{pgffor}

\usetheme{Warsaw}

\begin{document}

\section{title} 
\begin{frame}
\frametitle{title}
    abc
\end{frame} 

\section{Annexes}   
\setbeamertemplate{headline}{}
\begin{frame}
\frametitle{title}
    abc
\end{frame} 

\foreach \macro in {0,...,100}{
\begin{frame}
	abc
\end{frame}	
}
\end{document}
```
