### PR TITLE
Update location of license file

### DIFF
--- a/base/art/beamericonarticle.tex
+++ b/base/art/beamericonarticle.tex
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass[12pt]{article}
 

--- a/base/art/beamericonbook.tex
+++ b/base/art/beamericonbook.tex
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass[12pt]{article}
 

--- a/base/beamer.cls
+++ b/base/beamer.cls
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \ProvidesClass{beamer}
   [2023/02/20 v3.69 A class for typesetting presentations]

--- a/base/beamerarticle.sty
+++ b/base/beamerarticle.sty
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \ProvidesPackage{beamerarticle}
   [2023/02/20 v3.69 beamer input in article mode]

--- a/base/beamerbasearticle.sty
+++ b/base/beamerbasearticle.sty
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \newif\ifbeamer@articleutf
 \beamer@articleutffalse

--- a/base/beamerbaseauxtemplates.sty
+++ b/base/beamerbaseauxtemplates.sty
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/beamerbaseboxes.sty
+++ b/base/beamerbaseboxes.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \def\beamerboxesdeclarecolorscheme#1#2#3{% scheme name, upper color, lower color
   \setbeamercolor{@scheme upper #1}{fg=white,bg={#2}}

--- a/base/beamerbasecolor.sty
+++ b/base/beamerbasecolor.sty
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbasecompatibility.sty
+++ b/base/beamerbasecompatibility.sty
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbasedecode.sty
+++ b/base/beamerbasedecode.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 % To track which slide we are on in a frame
 \newcount\beamer@slideinframe

--- a/base/beamerbasefont.sty
+++ b/base/beamerbasefont.sty
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 % For \blacktriangleright; not explicitly required by article, but can cause
 % weird situations if users find that symbols works in presentation, but not

--- a/base/beamerbaseframe.sty
+++ b/base/beamerbaseframe.sty
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbaseframecomponents.sty
+++ b/base/beamerbaseframecomponents.sty
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbaseframesize.sty
+++ b/base/beamerbaseframesize.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbaselocalstructure.sty
+++ b/base/beamerbaselocalstructure.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <all>

--- a/base/beamerbasemisc.sty
+++ b/base/beamerbasemisc.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbasemodes.sty
+++ b/base/beamerbasemodes.sty
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 % Force e-TeX and provide \patchcmd
 \RequirePackage{etoolbox}

--- a/base/beamerbasenavigation.sty
+++ b/base/beamerbasenavigation.sty
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbasenavigationsymbols.tex
+++ b/base/beamerbasenavigationsymbols.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \pgfdefobject{beamerslidenavlight}{\pgfpoint{0pt}{-1pt}}{\pgfpoint{20pt}{5pt}}
  {\pgfpathqmoveto{4bp}{0.5bp}

--- a/base/beamerbasenotes.sty
+++ b/base/beamerbasenotes.sty
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbaseoptions.sty
+++ b/base/beamerbaseoptions.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \RequirePackage{keyval}[1997/11/10]
 

--- a/base/beamerbaseoverlay.sty
+++ b/base/beamerbaseoverlay.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 % Many of these commans allow an overlay spec either before or after
 % their argument (though not in both positions), hence the repetition

--- a/base/beamerbaserequires.sty
+++ b/base/beamerbaserequires.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 %
 % Beamer packages

--- a/base/beamerbasesection.sty
+++ b/base/beamerbasesection.sty
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <all>

--- a/base/beamerbasetemplates.sty
+++ b/base/beamerbasetemplates.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 %
 % Template Installation Commands

--- a/base/beamerbasethemes.sty
+++ b/base/beamerbasethemes.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 %
 % Basic commands for including themes

--- a/base/beamerbasetheorems.sty
+++ b/base/beamerbasetheorems.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbasetitle.sty
+++ b/base/beamerbasetitle.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbasetoc.sty
+++ b/base/beamerbasetoc.sty
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/beamerbasetranslator.sty
+++ b/base/beamerbasetranslator.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 %
 % Load translator and it's dictionaries

--- a/base/beamerbasetwoscreens.sty
+++ b/base/beamerbasetwoscreens.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 %
 % version 1.71 bugfix for \pgfpagescurrentpagewillbelogicalpage (hv)
 %

--- a/base/beamerbaseverbatim.sty
+++ b/base/beamerbaseverbatim.sty
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode
 <presentation>

--- a/base/emulation/beamerfoils.sty
+++ b/base/emulation/beamerfoils.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \let\leftheader=\@gobble
 \let\rightheader=\@gobble

--- a/base/emulation/beamerprosper.sty
+++ b/base/emulation/beamerprosper.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \let\beamerprosper@entry=\@gobble
 

--- a/base/emulation/beamerseminar.sty
+++ b/base/emulation/beamerseminar.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \newif\ifbeamerseminar@accumulated
 \beamerseminar@accumulatedfalse

--- a/base/emulation/beamertexpower.sty
+++ b/base/emulation/beamertexpower.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \long\def\stepwise#1{{\nonboxedsteps#1}}
 \long\def\parstepwise#1{{\boxedsteps#1}}

--- a/base/multimedia/multimedia.sty
+++ b/base/multimedia/multimedia.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \ProvidesPackage{multimedia}[2012/05/02 ver 0.02]
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]

--- a/base/multimedia/multimediasymbols.sty
+++ b/base/multimedia/multimediasymbols.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \ProvidesPackage{multimediasymbols}[2004/04/10 ver 0.01]
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]

--- a/base/patch/beamerpatchparalist.sty
+++ b/base/patch/beamerpatchparalist.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemealbatross.sty
+++ b/base/themes/color/beamercolorthemealbatross.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \setbeamercolor*{normal text}{fg=yellow!50!white,bg=blue!50!black}
 

--- a/base/themes/color/beamercolorthemebeaver.sty
+++ b/base/themes/color/beamercolorthemebeaver.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemebeetle.sty
+++ b/base/themes/color/beamercolorthemebeetle.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemecrane.sty
+++ b/base/themes/color/beamercolorthemecrane.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemedefault.sty
+++ b/base/themes/color/beamercolorthemedefault.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemedolphin.sty
+++ b/base/themes/color/beamercolorthemedolphin.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemedove.sty
+++ b/base/themes/color/beamercolorthemedove.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemefly.sty
+++ b/base/themes/color/beamercolorthemefly.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemelily.sty
+++ b/base/themes/color/beamercolorthemelily.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthememonarca.sty
+++ b/base/themes/color/beamercolorthememonarca.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 % 
 % This theme is based on the crane theme by Till Tantau.
 % the OVERLYSTYLISH option is taken from the albatross theme

--- a/base/themes/color/beamercolorthemeorchid.sty
+++ b/base/themes/color/beamercolorthemeorchid.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemerose.sty
+++ b/base/themes/color/beamercolorthemerose.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemeseagull.sty
+++ b/base/themes/color/beamercolorthemeseagull.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemeseahorse.sty
+++ b/base/themes/color/beamercolorthemeseahorse.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemesidebartab.sty
+++ b/base/themes/color/beamercolorthemesidebartab.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemespruce.sty
+++ b/base/themes/color/beamercolorthemespruce.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 %
 
 \mode<presentation>

--- a/base/themes/color/beamercolorthemestructure.sty
+++ b/base/themes/color/beamercolorthemestructure.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{gray}{\definecolor{beamer@structure@color}{gray}{#1}}
 \DeclareOptionBeamer{rgb}{\definecolor{beamer@structure@color}{rgb}{#1}}

--- a/base/themes/color/beamercolorthemewhale.sty
+++ b/base/themes/color/beamercolorthemewhale.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/color/beamercolorthemewolverine.sty
+++ b/base/themes/color/beamercolorthemewolverine.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/font/beamerfontthemedefault.sty
+++ b/base/themes/font/beamerfontthemedefault.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/font/beamerfontthemeprofessionalfonts.sty
+++ b/base/themes/font/beamerfontthemeprofessionalfonts.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>{\beamer@suppressreplacementstrue}
 

--- a/base/themes/font/beamerfontthemeserif.sty
+++ b/base/themes/font/beamerfontthemeserif.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{stillsansserifmath}[]{\def\mathfamilydefault{\sfdefault}\beamer@sansmathtrue}
 \DeclareOptionBeamer{stillsansserifsmall}[]{\def\beamer@tsfont{\sffamily}}

--- a/base/themes/font/beamerfontthemestructurebold.sty
+++ b/base/themes/font/beamerfontthemestructurebold.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \def\beamer@ftb@str{
   \setbeamerfont{structure}{series=\bfseries}

--- a/base/themes/font/beamerfontthemestructureitalicserif.sty
+++ b/base/themes/font/beamerfontthemestructureitalicserif.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \def\beamer@ftb@str{%
   \setbeamerfont{structure}{shape=\itshape,family=\rmfamily}

--- a/base/themes/font/beamerfontthemestructuresmallcapsserif.sty
+++ b/base/themes/font/beamerfontthemestructuresmallcapsserif.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \def\beamer@ftb@str{
   \setbeamerfont{structure}{shape=\scshape,family=\rmfamily}

--- a/base/themes/inner/beamerinnerthemecircles.sty
+++ b/base/themes/inner/beamerinnerthemecircles.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/inner/beamerinnerthemedefault.sty
+++ b/base/themes/inner/beamerinnerthemedefault.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/inner/beamerinnerthemeinmargin.sty
+++ b/base/themes/inner/beamerinnerthemeinmargin.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/inner/beamerinnerthemerectangles.sty
+++ b/base/themes/inner/beamerinnerthemerectangles.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/inner/beamerinnerthemerounded.sty
+++ b/base/themes/inner/beamerinnerthemerounded.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{shadow}[true]{\def\beamer@themerounded@shadow{#1}}
 \ExecuteOptionsBeamer{shadow=false}

--- a/base/themes/outer/beamerouterthemedefault.sty
+++ b/base/themes/outer/beamerouterthemedefault.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/outer/beamerouterthemeinfolines.sty
+++ b/base/themes/outer/beamerouterthemeinfolines.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/outer/beamerouterthememiniframes.sty
+++ b/base/themes/outer/beamerouterthememiniframes.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \setbeamercolor{section in head/foot}{parent=palette tertiary}
 \setbeamercolor{subsection in head/foot}{parent=palette secondary}

--- a/base/themes/outer/beamerouterthemeshadow.sty
+++ b/base/themes/outer/beamerouterthemeshadow.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/outer/beamerouterthemesidebar.sty
+++ b/base/themes/outer/beamerouterthemesidebar.sty
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \let\beamer@storesize\@currsize
 \newdimen\beamer@sidebarwidth

--- a/base/themes/outer/beamerouterthemesmoothbars.sty
+++ b/base/themes/outer/beamerouterthemesmoothbars.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \newif\ifbeamer@sb@subsection
 

--- a/base/themes/outer/beamerouterthemesmoothtree.sty
+++ b/base/themes/outer/beamerouterthemesmoothtree.sty
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/outer/beamerouterthemesplit.sty
+++ b/base/themes/outer/beamerouterthemesplit.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/outer/beamerouterthemetree.sty
+++ b/base/themes/outer/beamerouterthemetree.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \newif\ifbeamer@tree@showhooks
 \beamer@tree@showhookstrue

--- a/base/themes/theme/beamerthemeAnnArbor.sty
+++ b/base/themes/theme/beamerthemeAnnArbor.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeAntibes.sty
+++ b/base/themes/theme/beamerthemeAntibes.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeBergen.sty
+++ b/base/themes/theme/beamerthemeBergen.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeBerkeley.sty
+++ b/base/themes/theme/beamerthemeBerkeley.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{hideothersubsections}{\PassOptionsToPackage{hideothersubsections=#1}{beamerouterthemesidebar}}
 \DeclareOptionBeamer{hideallsubsections}{\PassOptionsToPackage{hideallsubsections=#1}{beamerouterthemesidebar}}

--- a/base/themes/theme/beamerthemeBerlin.sty
+++ b/base/themes/theme/beamerthemeBerlin.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{compress}{\beamer@compresstrue}
 \ProcessOptionsBeamer

--- a/base/themes/theme/beamerthemeBoadilla.sty
+++ b/base/themes/theme/beamerthemeBoadilla.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeCambridgeUS.sty
+++ b/base/themes/theme/beamerthemeCambridgeUS.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeCopenhagen.sty
+++ b/base/themes/theme/beamerthemeCopenhagen.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeDarmstadt.sty
+++ b/base/themes/theme/beamerthemeDarmstadt.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeDresden.sty
+++ b/base/themes/theme/beamerthemeDresden.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{compress}{\beamer@compresstrue}
 \ProcessOptionsBeamer

--- a/base/themes/theme/beamerthemeEastLansing.sty
+++ b/base/themes/theme/beamerthemeEastLansing.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 %
 
 \mode<presentation>

--- a/base/themes/theme/beamerthemeFrankfurt.sty
+++ b/base/themes/theme/beamerthemeFrankfurt.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeGoettingen.sty
+++ b/base/themes/theme/beamerthemeGoettingen.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{hideothersubsections}{\PassOptionsToPackage{hideothersubsections}{beamerouterthemesidebar}}
 \DeclareOptionBeamer{hideallsubsections}{\PassOptionsToPackage{hideallsubsections}{beamerouterthemesidebar}}

--- a/base/themes/theme/beamerthemeHannover.sty
+++ b/base/themes/theme/beamerthemeHannover.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{width}
 {\PassOptionsToPackage{width=#1}{beamerouterthemesidebar}}

--- a/base/themes/theme/beamerthemeIlmenau.sty
+++ b/base/themes/theme/beamerthemeIlmenau.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{compress}{\beamer@compresstrue}
 \ProcessOptionsBeamer

--- a/base/themes/theme/beamerthemeJuanLesPins.sty
+++ b/base/themes/theme/beamerthemeJuanLesPins.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeLuebeck.sty
+++ b/base/themes/theme/beamerthemeLuebeck.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeMadrid.sty
+++ b/base/themes/theme/beamerthemeMadrid.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeMalmoe.sty
+++ b/base/themes/theme/beamerthemeMalmoe.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeMarburg.sty
+++ b/base/themes/theme/beamerthemeMarburg.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \PassOptionsToPackage{right}{beamerouterthemesidebar}
 \PassOptionsToPackage{width=2cm}{beamerouterthemesidebar}

--- a/base/themes/theme/beamerthemeMontpellier.sty
+++ b/base/themes/theme/beamerthemeMontpellier.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemePaloAlto.sty
+++ b/base/themes/theme/beamerthemePaloAlto.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{hideothersubsections}{\PassOptionsToPackage{hideothersubsections=#1}{beamerouterthemesidebar}}
 \DeclareOptionBeamer{hideallsubsections}{\PassOptionsToPackage{hideallsubsections=#1}{beamerouterthemesidebar}}

--- a/base/themes/theme/beamerthemePittsburgh.sty
+++ b/base/themes/theme/beamerthemePittsburgh.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeRochester.sty
+++ b/base/themes/theme/beamerthemeRochester.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{height}{\PassOptionsToPackage{height=#1}{beamerouterthemesidebar}}
 \ProcessOptionsBeamer

--- a/base/themes/theme/beamerthemeSingapore.sty
+++ b/base/themes/theme/beamerthemeSingapore.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{compress}{\beamer@compresstrue}
 \ProcessOptionsBeamer

--- a/base/themes/theme/beamerthemeSzeged.sty
+++ b/base/themes/theme/beamerthemeSzeged.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{compress}{\beamer@compresstrue}
 \ProcessOptionsBeamer

--- a/base/themes/theme/beamerthemeWarsaw.sty
+++ b/base/themes/theme/beamerthemeWarsaw.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/beamerthemeboxes.sty
+++ b/base/themes/theme/beamerthemeboxes.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \DeclareOptionBeamer{headheight}{\beamer@boxheadheight=#1}
 \DeclareOptionBeamer{footheight}{\beamer@boxfootheight=#1}

--- a/base/themes/theme/beamerthemedefault.sty
+++ b/base/themes/theme/beamerthemedefault.sty
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/compatibility/beamerthemebars.sty
+++ b/base/themes/theme/compatibility/beamerthemebars.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/compatibility/beamerthemeclassic.sty
+++ b/base/themes/theme/compatibility/beamerthemeclassic.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/compatibility/beamerthemecompatibility.sty
+++ b/base/themes/theme/compatibility/beamerthemecompatibility.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/compatibility/beamerthemelined.sty
+++ b/base/themes/theme/compatibility/beamerthemelined.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/compatibility/beamerthemeplain.sty
+++ b/base/themes/theme/compatibility/beamerthemeplain.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/compatibility/beamerthemeshadow.sty
+++ b/base/themes/theme/compatibility/beamerthemeshadow.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/compatibility/beamerthemesidebar.sty
+++ b/base/themes/theme/compatibility/beamerthemesidebar.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \newif\ifbeamer@sidebartab
 \newif\ifbeamer@sidebardark

--- a/base/themes/theme/compatibility/beamerthemesplit.sty
+++ b/base/themes/theme/compatibility/beamerthemesplit.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/base/themes/theme/compatibility/beamerthemetree.sty
+++ b/base/themes/theme/compatibility/beamerthemetree.sty
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \mode<presentation>
 

--- a/doc/beamercolorthemeexample.tex
+++ b/doc/beamercolorthemeexample.tex
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass[hyperref={draft}]{beamer}
 

--- a/doc/beamerfontthemeexample.tex
+++ b/doc/beamerfontthemeexample.tex
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass[hyperref={draft}]{beamer}
 

--- a/doc/beamerinnerthemeexample.tex
+++ b/doc/beamerinnerthemeexample.tex
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass[hyperref={draft}]{beamer}
 

--- a/doc/beamerouterthemeexample.tex
+++ b/doc/beamerouterthemeexample.tex
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass[hyperref={draft}]{beamer}
 

--- a/doc/beamerthemeexample.tex
+++ b/doc/beamerthemeexample.tex
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass[hyperref={draft}]{beamer}
 

--- a/doc/beamerthemeexamplebase.tex
+++ b/doc/beamerthemeexamplebase.tex
@@ -7,7 +7,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \beamertemplatesolidbackgroundcolor{black!5}
 \beamertemplatetransparentcovered

--- a/doc/beamerug-animations.tex
+++ b/doc/beamerug-animations.tex
@@ -11,7 +11,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Animations, Sounds, and Slide Transitions}
 

--- a/doc/beamerug-color.tex
+++ b/doc/beamerug-color.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Colors}
 

--- a/doc/beamerug-compatibility.tex
+++ b/doc/beamerug-compatibility.tex
@@ -11,7 +11,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \subsection{Compatibility with Other Packages and Classes}
 

--- a/doc/beamerug-elements.tex
+++ b/doc/beamerug-elements.tex
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Inner Themes, Outer Themes, and Templates}
 \label{section-elements}

--- a/doc/beamerug-emulation.tex
+++ b/doc/beamerug-emulation.tex
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section[How To Import Presentations Based on Other Packages and Classes]{How To Import Presentations Based on\\ Other Packages and Classes}
 

--- a/doc/beamerug-fonts.tex
+++ b/doc/beamerug-fonts.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Fonts}
 \label{section-fonts}

--- a/doc/beamerug-frames.tex
+++ b/doc/beamerug-frames.tex
@@ -11,7 +11,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Creating Frames}
 \label{section-frames}

--- a/doc/beamerug-globalstructure.tex
+++ b/doc/beamerug-globalstructure.tex
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Structuring a Presentation: The Static Global Structure}
 

--- a/doc/beamerug-graphics.tex
+++ b/doc/beamerug-graphics.tex
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Graphics}
 \label{section-graphics}

--- a/doc/beamerug-guidelines.tex
+++ b/doc/beamerug-guidelines.tex
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Guidelines for Creating Presentations}
 \label{section-guidelines}

--- a/doc/beamerug-installation.tex
+++ b/doc/beamerug-installation.tex
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Installation}
 \label{section-installation}

--- a/doc/beamerug-interaction.tex
+++ b/doc/beamerug-interaction.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Structuring a Presentation: The Interactive Global Structure}
 \label{section-nonlinear}

--- a/doc/beamerug-introduction.tex
+++ b/doc/beamerug-introduction.tex
@@ -11,7 +11,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Introduction}
 

--- a/doc/beamerug-license.tex
+++ b/doc/beamerug-license.tex
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Licenses and Copyright}
 \label{section-license}

--- a/doc/beamerug-localstructure.tex
+++ b/doc/beamerug-localstructure.tex
@@ -11,7 +11,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Structuring a Presentation: The Local Structure}
 

--- a/doc/beamerug-macros.tex
+++ b/doc/beamerug-macros.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \def\beamer{\textsc{beamer}}
 \def\pdf{\textsc{pdf}}

--- a/doc/beamerug-nonpresentation.tex
+++ b/doc/beamerug-nonpresentation.tex
@@ -11,7 +11,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Creating Handouts and Lecture Notes}
 \label{section-modes}

--- a/doc/beamerug-notes.tex
+++ b/doc/beamerug-notes.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Adding Notes for Yourself}
 

--- a/doc/beamerug-overlays.tex
+++ b/doc/beamerug-overlays.tex
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Creating Overlays}
 \label{section-overlay}

--- a/doc/beamerug-solutions.tex
+++ b/doc/beamerug-solutions.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Solution Templates}
 \label{section-solutions}

--- a/doc/beamerug-themes.tex
+++ b/doc/beamerug-themes.tex
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Themes}
 

--- a/doc/beamerug-transparencies.tex
+++ b/doc/beamerug-transparencies.tex
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Creating Transparencies}
 \label{section-trans}

--- a/doc/beamerug-tricks.tex
+++ b/doc/beamerug-tricks.tex
@@ -8,7 +8,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{How To Uncover Things Piecewise}
 

--- a/doc/beamerug-tutorial.tex
+++ b/doc/beamerug-tutorial.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Tutorial: Euclid's Presentation}
 \label{section-tutorial}

--- a/doc/beamerug-twoscreens.tex
+++ b/doc/beamerug-twoscreens.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Taking Advantage of Multiple Screens}
 \label{section-twoscreens}

--- a/doc/beamerug-workflow.tex
+++ b/doc/beamerug-workflow.tex
@@ -9,7 +9,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \section{Workflow For Creating a Beamer Presentation}
 \label{section-workflow}

--- a/doc/beameruserguide.tex
+++ b/doc/beameruserguide.tex
@@ -10,7 +10,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Free Documentation License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass{ltxdoc}
 

--- a/doc/emulation-examples/beamerexample-foils.tex
+++ b/doc/emulation-examples/beamerexample-foils.tex
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 % $Header$
 

--- a/doc/emulation-examples/beamerexample-prosper.tex
+++ b/doc/emulation-examples/beamerexample-prosper.tex
@@ -6,7 +6,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 % $Header$
 

--- a/doc/examples/a-conference-talk/beamerexample-conference-talk.tex
+++ b/doc/examples/a-conference-talk/beamerexample-conference-talk.tex
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 
 

--- a/doc/examples/a-lecture/beamerexample-lecture-beamer-version.tex
+++ b/doc/examples/a-lecture/beamerexample-lecture-beamer-version.tex
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass[german,10pt]{beamer}
 

--- a/doc/examples/a-lecture/beamerexample-lecture-body.tex
+++ b/doc/examples/a-lecture/beamerexample-lecture-body.tex
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 %
 % DO NOT USE THIS FILE AS A TEMPLATE FOR YOUR OWN TALKS¡!!

--- a/doc/examples/a-lecture/beamerexample-lecture-print-version.tex
+++ b/doc/examples/a-lecture/beamerexample-lecture-print-version.tex
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 \documentclass[german,a4paper,9pt]{extarticle}
 \usepackage{beamerarticle}

--- a/doc/examples/a-lecture/beamerexample-lecture-style.tex
+++ b/doc/examples/a-lecture/beamerexample-lecture-style.tex
@@ -5,7 +5,7 @@
 % 1. under the LaTeX Project Public License and/or
 % 2. under the GNU Public License.
 %
-% See the file doc/licenses/LICENSE for more details.
+% See the file LICENSE.md for more details.
 
 
 % Common packages


### PR DESCRIPTION
Since https://github.com/josephwright/beamer/commit/83c4a3727bac1d6c2e1799534cd2c8268c0b77b3 the file doc/licenses/LICENSE no longer exists, pointing to the top level LICENSE.md file instead