### PR TITLE
Modular title page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ a major and minor version only.
 ### Added
 
 - making the aspect ratio available to the user via `\insertaspectratio`
+- adding `title`, `author`, `institute`, `date` and `titlegraphic` templates to make title page easier to customise
 
 ### Changed
 

--- a/base/themes/inner/beamerinnerthemedefault.sty
+++ b/base/themes/inner/beamerinnerthemedefault.sty
@@ -1,7 +1,7 @@
 % Copyright 2007 by Till Tantau
 % Copyright 2012--2015 by Vedran Mileti\'c, Joseph Wright
 % Copyright 2017,2018 by Louis Stuart, Joseph Wright
-% Copyright 2021 by Joseph Wright, samcarter
+% Copyright 2021,2023 by Joseph Wright, samcarter
 %
 % This file may be distributed and/or modified
 %
@@ -38,35 +38,61 @@
 
 % Title page: default
 
+\defbeamertemplate{title}{default}[1][]{%
+  \begin{beamercolorbox}[sep=8pt,center,#1]{title}
+    \usebeamerfont{title}\inserttitle\par%
+    \ifx\insertsubtitle\@empty%
+    \else%
+      \vskip0.25em%
+      {\usebeamerfont{subtitle}\usebeamercolor[fg]{subtitle}\insertsubtitle\par}%
+    \fi%     
+  \end{beamercolorbox}%
+}
+
+\defbeamertemplate{author}{default}[1][]{%
+  \begin{beamercolorbox}[sep=8pt,center,#1]{author}
+    \usebeamerfont{author}\insertauthor
+  \end{beamercolorbox}
+}
+
+\defbeamertemplate{institute}{default}[1][]{%
+  \begin{beamercolorbox}[sep=8pt,center,#1]{institute}
+    \usebeamerfont{institute}\insertinstitute
+  \end{beamercolorbox}
+}
+
+\defbeamertemplate{date}{default}[1][]{%
+    \begin{beamercolorbox}[sep=8pt,center,#1]{date}
+      \usebeamerfont{date}\insertdate
+    \end{beamercolorbox}
+}
+
+\defbeamertemplate{titlegraphic}{default}{%
+  {\usebeamercolor[fg]{titlegraphic}\inserttitlegraphic\par}
+}
+
 \defbeamertemplate*{title page}{default}[1][]
 {
   \vbox{}
   \vfill
   \begingroup
     \centering
-    \begin{beamercolorbox}[sep=8pt,center,#1]{title}
-      \usebeamerfont{title}\inserttitle\par%
-      \ifx\insertsubtitle\@empty%
-      \else%
-        \vskip0.25em%
-        {\usebeamerfont{subtitle}\usebeamercolor[fg]{subtitle}\insertsubtitle\par}%
-      \fi%     
-    \end{beamercolorbox}%
+    \usebeamertemplate{title}
     \vskip1em\par
-    \begin{beamercolorbox}[sep=8pt,center,#1]{author}
-      \usebeamerfont{author}\insertauthor
-    \end{beamercolorbox}
-    \begin{beamercolorbox}[sep=8pt,center,#1]{institute}
-      \usebeamerfont{institute}\insertinstitute
-    \end{beamercolorbox}
-    \begin{beamercolorbox}[sep=8pt,center,#1]{date}
-      \usebeamerfont{date}\insertdate
-    \end{beamercolorbox}\vskip0.5em
-    {\usebeamercolor[fg]{titlegraphic}\inserttitlegraphic\par}
+    \usebeamertemplate{author}
+    \usebeamertemplate{institute}
+    \usebeamertemplate{date}
+    \vskip0.5em
+    \usebeamertemplate{titlegraphic}
   \endgroup
   \vfill
+}[action]{
+  \setbeamertemplate{title}[default][#1]
+  \setbeamertemplate{author}[default][#1]
+  \setbeamertemplate{institute}[default][#1]
+  \setbeamertemplate{date}[default][#1]
+  \setbeamertemplate{titlegraphic}[default]
 }
-
 
 % Part page: default
 

--- a/base/themes/inner/beamerinnerthemeinmargin.sty
+++ b/base/themes/inner/beamerinnerthemeinmargin.sty
@@ -58,30 +58,46 @@
 \def\insertinstituteindicator{\translate{From?}}
 \def\insertdateindicator{\translate{When?}}
 
-\defbeamertemplate*{title page}{inmargin}
-{
+\setbeamertemplate{title}{%
   \begin{block}{\inserttitleindicator}
     \usebeamercolor[fg]{title}\usebeamerfont{title}\inserttitle\par
     \usebeamercolor[fg]{subtitle}\usebeamerfont{subtitle}\insertsubtitle
   \end{block}
-  \vfill
+}
+
+\setbeamertemplate{author}{%
   \expandafter\ifblank\expandafter{\beamer@andstripped}{}{%
   \begin{block}{\insertauthorindicator}
     \usebeamercolor[fg]{author}\usebeamerfont{author}\insertauthor\par
   \end{block}
   }
+}
+
+\setbeamertemplate{institute}{%
   \ifx\insertinstitute\@empty
   \else
   \begin{block}{\insertinstituteindicator}
     \usebeamercolor[fg]{institute}\usebeamerfont{institute}\insertinstitute\par
   \end{block}
   \fi
+}
+
+\setbeamertemplate{date}{%
   \ifx\insertdate\@empty
   \else
   \begin{block}{\insertdateindicator}
     \usebeamercolor[fg]{date}\usebeamerfont{date}\insertdate\par
   \end{block}
   \fi
+}
+
+\defbeamertemplate*{title page}{inmargin}
+{
+  \usebeamertemplate{title}
+  \vfill
+  \usebeamertemplate{author}
+  \usebeamertemplate{institute}
+  \usebeamertemplate{date}
 }
 
 \defbeamertemplate*{block begin}{inmargin}

--- a/doc/beamerug-globalstructure.tex
+++ b/doc/beamerug-globalstructure.tex
@@ -32,8 +32,18 @@ You can use the |\titlepage| command to insert a title page into a frame. By def
 
     \begin{templateoptions}
       \itemoption{default}{\oarg{alignment}}
-      The title page is typeset showing the title, followed by the author, his or her affiliation, the date, and a titlegraphic. If any of these are missing, they are not shown. Except for the titlegraphic, if the \beamer-color |title|, |author|, |institute|, or |date| is defined, respectively, it is used as textcolor for these entries. If a background color is defined for them, a colored bar in the corresponding color is drawn behind them, spanning the text width. The corresponding \beamer-fonts are used for these entries.
-
+      The title page is typeset showing the title, followed by the author, their affiliation, the date, and a titlegraphic. If any of these are missing, they are not shown. Except for the titlegraphic, if the \beamer-color |title|, |author|, |institute|, or |date| is defined, respectively, it is used as textcolor for these entries. If a background color is defined for them, a colored bar in the corresponding color is drawn behind them, spanning the text width. The corresponding \beamer-fonts are used for these entries. The following templates are used by the title page:
+      \begin{element}{title}\yes\yes\yes
+      \end{element}
+      \begin{element}{author}\yes\yes\yes
+      \end{element}
+      \begin{element}{institute}\yes\yes\yes
+      \end{element}
+      \begin{element}{date}\yes\yes\yes
+      \end{element}
+      \begin{element}{titlegraphic}\yes\no\no
+      \end{element}      
+      
       The \meta{alignment} option is passed on the |beamercolorbox| and can be used, for example, to flush the title page to the left by specifying |left| here.
     \end{templateoptions}
 


### PR DESCRIPTION
A reoccurring theme in beamer question is modifying the title page. Users ask how to change the spacing, how to add information like the name of a supervisor etc.

Answers will either use dirty hacks, like adding formatting instructions in the `\author` macro, abusing other fields, or need to redefine the whole title page.

I propose to make the title page a bit less monolithic and use templates to insert the title/author/etc. blocks. This way users can easily add information via `\addtobeamertemplate{author}{...}{...}` or redefine just a specific template instead of the whole title page.

Usage example:

```
\documentclass{beamer}
\usetheme{Warsaw}
\title{Title}
\author{Speaker name}

\addtobeamertemplate{author}{}{Supervisor: The Bär}

\begin{document}
\maketitle
\end{document}
```