### PR TITLE
making `\part` compatible with `\nameref`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ a major and minor version only.
 - made top shading of Singapore theme transparent (see #782)
 - scale height of infolines headline with fontsize of `section in head/foot`
 - calculate the head/footheight at the start of each frame instead of only at the start of the document
+- making `\part` compatible with `\nameref`
 
 ### Fixed
 

--- a/base/beamerbasesection.sty
+++ b/base/beamerbasesection.sty
@@ -102,6 +102,8 @@
 
 \newcommand<>{\part}{\alt#1{\@dblarg\beamer@part}{\beamer@gobbleoptional}}
 \long\def\beamer@part[#1]#2{%
+  \GetTitleString{#1}%
+  \let\@currentlabelname\GetTitleStringResult
   \beamer@savemode
   \mode<all>%
   \ifbeamer@inlecture


### PR DESCRIPTION
Test document:

```
\documentclass{beamer}

\begin{document}

\part{title}
\label{foo}

\begin{frame}
	\nameref{foo}
\end{frame}	
	
\end{document}
```