### PR TITLE
scale height of tree and split headlines with fontsize of `section in head/foot`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a major and minor version only.
 
 ## [Unreleased]
 
+### Changed
+
+- scale height of tree and split headlines with fontsize of `section in head/foot`
+
 ## [v3.70]
 
 ### Added

--- a/base/beamerbasesection.sty
+++ b/base/beamerbasesection.sty
@@ -2,7 +2,7 @@
 % Copyright 2010 by Vedran Mileti\'c
 % Copyright 2012,2013,2015 by Vedran Mileti\'c, Joseph Wright
 % Copyright 2017,2018 by Louis Stuart, Joseph Wright
-% Copyright 2021 by Joseph Wright, samcarter
+% Copyright 2021,2023 by Joseph Wright, samcarter
 %
 % This file may be distributed and/or modified
 %

--- a/base/themes/outer/beamerouterthemesplit.sty
+++ b/base/themes/outer/beamerouterthemesplit.sty
@@ -1,5 +1,6 @@
 % Copyright 2007 by Till Tantau
 % Copyright 2012,2015 by Vedran Mileti\'c, Joseph Wright
+% Copyright 2023 by Joseph Wright, samcarter
 %
 % This file may be distributed and/or modified
 %
@@ -28,12 +29,14 @@
 \defbeamertemplate*{headline}{split theme}
 {%
   \leavevmode%
+  {\usebeamerfont{section in head/foot}%
   \begin{beamercolorbox}[wd=.5\paperwidth,ht=2.5ex,dp=1.125ex]{section in head/foot}%
     \insertsectionnavigationhorizontal{.5\paperwidth}{\hskip0pt plus1filll}{}%
   \end{beamercolorbox}%
   \begin{beamercolorbox}[wd=.5\paperwidth,ht=2.5ex,dp=1.125ex]{subsection in head/foot}%
+    \usebeamerfont{subsection in head/foot}%
     \insertsubsectionnavigationhorizontal{.5\paperwidth}{}{\hskip0pt plus1filll}%
-  \end{beamercolorbox}%
+  \end{beamercolorbox}}%
 }
 
 \else
@@ -41,6 +44,7 @@
 \defbeamertemplate*{headline}{split theme}
 {%
   \leavevmode%
+  {\usebeamerfont{section in head/foot}%
   \@tempdimb=2.4375ex%
   \ifnum\beamer@subsectionmax<\beamer@sectionmax%
     \multiply\@tempdimb by\beamer@sectionmax%
@@ -50,12 +54,13 @@
   \ifdim\@tempdimb>0pt%
     \advance\@tempdimb by 1.825ex%
     \begin{beamercolorbox}[wd=.5\paperwidth,ht=\@tempdimb]{section in head/foot}%
-      \vbox to\@tempdimb{\vfil\insertsectionnavigation{.5\paperwidth}\vfil}%
+      \vbox to\@tempdimb{\vfil\usebeamerfont{section in head/foot}\insertsectionnavigation{.5\paperwidth}\vfil}%
     \end{beamercolorbox}%
     \begin{beamercolorbox}[wd=.5\paperwidth,ht=\@tempdimb]{subsection in head/foot}%
-      \vbox to\@tempdimb{\vfil\insertsubsectionnavigation{.5\paperwidth}\vfil}%
+      \vbox to\@tempdimb{\vfil\usebeamerfont{subsection in head/foot}\insertsubsectionnavigation{.5\paperwidth}\vfil}%
     \end{beamercolorbox}%
   \fi%
+  }%
 }
 
 \fi

--- a/base/themes/outer/beamerouterthemesplit.sty
+++ b/base/themes/outer/beamerouterthemesplit.sty
@@ -28,12 +28,14 @@
 \defbeamertemplate*{headline}{split theme}
 {%
   \leavevmode%
+  {\usebeamerfont{section in head/foot}%
   \begin{beamercolorbox}[wd=.5\paperwidth,ht=2.5ex,dp=1.125ex]{section in head/foot}%
     \insertsectionnavigationhorizontal{.5\paperwidth}{\hskip0pt plus1filll}{}%
   \end{beamercolorbox}%
   \begin{beamercolorbox}[wd=.5\paperwidth,ht=2.5ex,dp=1.125ex]{subsection in head/foot}%
+    \usebeamerfont{subsection in head/foot}%
     \insertsubsectionnavigationhorizontal{.5\paperwidth}{}{\hskip0pt plus1filll}%
-  \end{beamercolorbox}%
+  \end{beamercolorbox}}%
 }
 
 \else
@@ -41,6 +43,7 @@
 \defbeamertemplate*{headline}{split theme}
 {%
   \leavevmode%
+  {\usebeamerfont{section in head/foot}%
   \@tempdimb=2.4375ex%
   \ifnum\beamer@subsectionmax<\beamer@sectionmax%
     \multiply\@tempdimb by\beamer@sectionmax%
@@ -50,12 +53,13 @@
   \ifdim\@tempdimb>0pt%
     \advance\@tempdimb by 1.825ex%
     \begin{beamercolorbox}[wd=.5\paperwidth,ht=\@tempdimb]{section in head/foot}%
-      \vbox to\@tempdimb{\vfil\insertsectionnavigation{.5\paperwidth}\vfil}%
+      \vbox to\@tempdimb{\vfil\usebeamerfont{section in head/foot}\insertsectionnavigation{.5\paperwidth}\vfil}%
     \end{beamercolorbox}%
     \begin{beamercolorbox}[wd=.5\paperwidth,ht=\@tempdimb]{subsection in head/foot}%
-      \vbox to\@tempdimb{\vfil\insertsubsectionnavigation{.5\paperwidth}\vfil}%
+      \vbox to\@tempdimb{\vfil\usebeamerfont{subsection in head/foot}\insertsubsectionnavigation{.5\paperwidth}\vfil}%
     \end{beamercolorbox}%
   \fi%
+  }%
 }
 
 \fi

--- a/base/themes/outer/beamerouterthemetree.sty
+++ b/base/themes/outer/beamerouterthemetree.sty
@@ -1,5 +1,6 @@
 % Copyright 2007 by Till Tantau
 % Copyright 2015 by Vedran Mileti\'c, Joseph Wright
+% Copyright 2023 by Joseph Wright, samcarter
 %
 % This file may be distributed and/or modified
 %
@@ -20,13 +21,14 @@
 {%
     \begin{beamercolorbox}[wd=\paperwidth,colsep=1.5pt]{upper separation line head}
     \end{beamercolorbox}
+    {\usebeamerfont{title in head/foot}%
     \begin{beamercolorbox}[wd=\paperwidth,ht=2.5ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{title in head/foot}
-      \usebeamerfont{title in head/foot}\insertshorttitle
-    \end{beamercolorbox}
+      \insertshorttitle
+    \end{beamercolorbox}}
+    {\usebeamerfont{section in head/foot}%
     \begin{beamercolorbox}[wd=\paperwidth,ht=2.5ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{section in head/foot}
-      \usebeamerfont{section in head/foot}%
       \ifbeamer@tree@showhooks
         \setbox\beamer@tempbox=\hbox{\insertsectionhead}%
         \ifdim\wd\beamer@tempbox>1pt%
@@ -37,10 +39,10 @@
         \hskip6pt%
       \fi%
       \insertsectionhead
-    \end{beamercolorbox}
+    \end{beamercolorbox}}
+    {\usebeamerfont{subsection in head/foot}%
     \begin{beamercolorbox}[wd=\paperwidth,ht=2.5ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{subsection in head/foot}
-      \usebeamerfont{subsection in head/foot}%
       \ifbeamer@tree@showhooks
         \setbox\beamer@tempbox=\hbox{\insertsubsectionhead}%
         \ifdim\wd\beamer@tempbox>1pt%
@@ -51,7 +53,7 @@
         \hskip12pt%
       \fi%
       \insertsubsectionhead
-    \end{beamercolorbox}
+    \end{beamercolorbox}}
     \begin{beamercolorbox}[wd=\paperwidth,colsep=1.5pt]{lower separation line head}
     \end{beamercolorbox}
 }

--- a/base/themes/outer/beamerouterthemetree.sty
+++ b/base/themes/outer/beamerouterthemetree.sty
@@ -20,13 +20,14 @@
 {%
     \begin{beamercolorbox}[wd=\paperwidth,colsep=1.5pt]{upper separation line head}
     \end{beamercolorbox}
+    {\usebeamerfont{title in head/foot}%
     \begin{beamercolorbox}[wd=\paperwidth,ht=2.5ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{title in head/foot}
-      \usebeamerfont{title in head/foot}\insertshorttitle
-    \end{beamercolorbox}
+      \insertshorttitle
+    \end{beamercolorbox}}
+    {\usebeamerfont{section in head/foot}%
     \begin{beamercolorbox}[wd=\paperwidth,ht=2.5ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{section in head/foot}
-      \usebeamerfont{section in head/foot}%
       \ifbeamer@tree@showhooks
         \setbox\beamer@tempbox=\hbox{\insertsectionhead}%
         \ifdim\wd\beamer@tempbox>1pt%
@@ -37,10 +38,10 @@
         \hskip6pt%
       \fi%
       \insertsectionhead
-    \end{beamercolorbox}
+    \end{beamercolorbox}}
+    {\usebeamerfont{subsection in head/foot}%
     \begin{beamercolorbox}[wd=\paperwidth,ht=2.5ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{subsection in head/foot}
-      \usebeamerfont{subsection in head/foot}%
       \ifbeamer@tree@showhooks
         \setbox\beamer@tempbox=\hbox{\insertsubsectionhead}%
         \ifdim\wd\beamer@tempbox>1pt%
@@ -51,7 +52,7 @@
         \hskip12pt%
       \fi%
       \insertsubsectionhead
-    \end{beamercolorbox}
+    \end{beamercolorbox}}
     \begin{beamercolorbox}[wd=\paperwidth,colsep=1.5pt]{lower separation line head}
     \end{beamercolorbox}
 }


### PR DESCRIPTION
Test document:

```
\documentclass{beamer}

\usetheme{Warsaw}
%\useoutertheme{tree}

\title{text}

\setbeamerfont{section in head/foot}{size=\huge}
\setbeamerfont{subsection in head/foot}{size=\normalsize}

\begin{document}

\section{section}
\subsection{subsection}
\begin{frame}
	abc
\end{frame}	
	
\end{document}
```