### PR TITLE
Fix incorrect Beamer template names for `structureenv`

### DIFF
--- a/base/beamerbaselocalstructure.sty
+++ b/base/beamerbaselocalstructure.sty
@@ -86,8 +86,8 @@
       {\usebeamertemplate{alerted text end}}{\color{.}}{}\ignorespaces}{\ifhmode\unskip\fi\end{altenv}}
 
   \newenvironment<>{structureenv}{\begin{altenv}#1%
-      {\usebeamercolor[fg]{structure}\usebeamerfont{structure}\usebeamertemplate{structure text begin}}
-      {\usebeamertemplate{structure text end}}{\color{.}}{}\ignorespaces}{\ifhmode\unskip\fi\end{altenv}}
+      {\usebeamercolor[fg]{structure}\usebeamerfont{structure}\usebeamertemplate{structure begin}}
+      {\usebeamertemplate{structure end}}{\color{.}}{}\ignorespaces}{\ifhmode\unskip\fi\end{altenv}}
 
   \newcommand<>{\alert}[1]{\begin{alertenv}#2\relax#1\end{alertenv}}
   \newcommand<>{\structure}[1]{\begin{structureenv}#2\relax#1\end{structureenv}}


### PR DESCRIPTION
As per Section 12.2 of the Beamer User Guide for version 3.70, the Beamer template names for `structureenv` should be `structure begin` and `structure end`.  However, some of the Beamer package's source files are not using these exact names.

An issue caused by this is that, in article mode, text in `structureenv` is not typeset in boldface as specified also by Section 12.2.  A minimal working example is:

```tex
\documentclass{article}
\usepackage{beamerarticle}
\begin{document}
\begin{frame}
    \structure{This text should be typeset in boldface.}
\end{frame}
\end{document}
```