### PR TITLE
[ doc ] Handouts workflow: delete first line -> delete the first two

### DIFF
--- a/doc/beamerug-nonpresentation.tex
+++ b/doc/beamerug-nonpresentation.tex
@@ -168,7 +168,8 @@ The following workflow steps are optional, but they can simplify the creation of
 
 \begin{itemize}
 \item
-  In the main file |main.tex|, delete the first line, which sets the document class.
+  In the main file |main.tex|, delete the first two lines, which set the
+  document class and load the package |beamerarticle|.
 \item
   Create a file named, say, |main.beamer.tex| with the following content:
 


### PR DESCRIPTION
In the documentation for the handouts workflow it is necessary to delete the first two lines instead of the first line. This PR fixed this problem.