### PR TITLE
simplify decision tree for `\beamer@howtotreatframe`

### DIFF
--- a/base/beamerbaseframe.sty
+++ b/base/beamerbaseframe.sty
@@ -463,32 +463,24 @@
   \else%
     \gdef\beamer@whichframes{all:0}%
   \fi%
-  \ifx\beamer@againname\@empty%
-    \beamer@slideinframe=0\relax%
-    \beamer@anotherslidefalse%
-    \beamer@masterdecode{\beamer@whichframes}%
+  \beamer@slideinframe=0\relax%
+  \beamer@anotherslidefalse%
+  \beamer@masterdecode{\beamer@whichframes}%
+  \let\beamer@howtotreatframe\beamer@doseveralframes%
+  \ifbeamer@autobreak%
     \ifbeamer@anotherslide%
-        \let\beamer@howtotreatframe\beamer@doseveralframes%
-      \ifbeamer@containsverbatim%
-        \let\beamer@howtotreatframe\beamer@dosingleframe%
-      \fi%
-      \ifbeamer@autobreak%
-        \let\beamer@howtotreatframe\beamer@autobreakframe%
-      \fi%
-      \ifbeamer@isfragile%
-        \let\beamer@howtotreatframe\beamer@doexternalframe%
-      \fi%
-    \else% no slides in frame
+      \let\beamer@howtotreatframe\beamer@autobreakframe%
+    \fi%
+  \fi%
+  \ifbeamer@isfragile%
+    \let\beamer@howtotreatframe\beamer@doexternalframe%
+  \fi%
+  \ifbeamer@containsverbatim%
+    \ifbeamer@anotherslide%
+      \let\beamer@howtotreatframe\beamer@dosingleframe%
+    \else%
       \let\beamer@howtotreatframe\beamer@donoframe%
     \fi%
-  \else% again mode
-    \let\beamer@howtotreatframe\beamer@doseveralframes%
-    \ifbeamer@isfragile%
-      \let\beamer@howtotreatframe\beamer@doexternalframe%
-    \fi%
-    \ifbeamer@containsverbatim
-      \let\beamer@howtotreatframe\beamer@dosingleframe
-    \fi
   \fi%
   \beamer@howtotreatframe}
 \def\gobble@onslide{%


### PR DESCRIPTION
Expanding the frame environment relies on one of the following macros:

- `\beamer@doseveralframes` handles the "common case"

- `\beamer@doexternalframe` handles fragile frames, internally invoking the above macro when \frame is invoked recursively with fragile=false

- `\beamer@dosingleframe` handles fragile=singleslide frames without writing an intermediate file, so it doesn't invoke @doseveralframes and the frame cannot be reused via \againframe

- `\beamer@autobreakframe` handles allowframebreaks frames

- `\beamer@donoframe` typesets the frame in a temporary box, which is then discarded

Beamer used to choose between them by first branching on presence of a label, and when a label is NOT present, also by testing overlay specification to see if it yields no slides, via the following tree:

    if (no label)
        if (overlay specification not empty)
            if fragile=singleslide
                \beamer@dosingleframe
            elif allowframebreaks
                \beamer@autobreakframe
            elif fragile
                \beamer@doexternalframe
            else
                \beamer@doseveralframes
            fi
        else # empty overlay specification
            \beamer@donoframe
        fi
    else # has label
        if fragile
            \beamer@doexternalframe
        elif fragile=singleslide
            \beamer@dosingleframe
        else
            \beamer@doseveralframes
        fi
    fi

This structure is confusing and leads to bugs such as #872 (allowframebreaks is not handled in presence of a label) and #873 (labeled fragile=singleslide frame shown despite `<all:0>` ospec).

It also uses \beamer@donoframe to suppress unlabeled slides, but it is inefficient (bug #866) compared to \beamer@doseveralframes which does not typeset the skipped content.

Use the following structure instead:

    take \beamer@doseveralframes unless overridden below:
    if allowframebreaks
        if ospec not empty
            \beamer@autobreakframe
        # else keep \beamer@doseveralframes
        fi
    fi
    if fragile
        \beamer@doexternalframe
    fi
    if fragile=singleslide
        if ospec not empty
            \beamer@dosingleframe
        else
            \beamer@donoframe
        fi
    fi

Fixes #866.
Fixes #872.
Fixes #873.