### PR TITLE
Unified usage of `section in head/foot` template in headlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ a major and minor version only.
 
 ### Changed
 
-- unified usage of `section in head/foot` template in headlines (`infolines`, `smoothtree` and `tree`)
+- unified usage of `(sub)section in head/foot` template in headlines
 
 ## [v3.71]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a major and minor version only.
 
 ## [Unreleased]
 
+### Changed
+
+- unified usage of `section in head/foot` template in headlines (`infolines`, `smoothtree` and `tree`)
+
 ## [v3.71]
 
 ### Changed

--- a/base/themes/outer/beamerouterthemeinfolines.sty
+++ b/base/themes/outer/beamerouterthemeinfolines.sty
@@ -49,10 +49,10 @@
   \hbox{%
   \usebeamerfont{section in head/foot}%
   \begin{beamercolorbox}[wd=.5\paperwidth,ht=2.65ex,dp=1.5ex,right]{section in head/foot}%
-    \usebeamerfont{headline}\usebeamerfont{section in head/foot}\insertsectionhead\hspace*{2ex}
+    \usebeamerfont{headline}\usebeamerfont{section in head/foot}\usebeamertemplate{section in head/foot}\hspace*{2ex}
   \end{beamercolorbox}%
   \begin{beamercolorbox}[wd=.5\paperwidth,ht=2.65ex,dp=1.5ex,left]{subsection in head/foot}%
-    \usebeamerfont{headline}\usebeamerfont{subsection in head/foot}\hspace*{2ex}\insertsubsectionhead
+    \usebeamerfont{headline}\usebeamerfont{subsection in head/foot}\hspace*{2ex}\usebeamertemplate{subsection in head/foot}
   \end{beamercolorbox}}%
   \vskip0pt%
 }

--- a/base/themes/outer/beamerouterthememiniframes.sty
+++ b/base/themes/outer/beamerouterthememiniframes.sty
@@ -112,7 +112,7 @@
     \end{beamercolorbox}
     \begin{beamercolorbox}[ht=2.5ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{subsection in head/foot}
-      \usebeamerfont{subsection in head/foot}\insertsubsectionhead
+      \usebeamerfont{subsection in head/foot}\usebeamertemplate{subsection in head/foot}
     \end{beamercolorbox}%
   \fi%
   \begin{beamercolorbox}[colsep=1.5pt]{lower separation line head}

--- a/base/themes/outer/beamerouterthemesmoothbars.sty
+++ b/base/themes/outer/beamerouterthemesmoothbars.sty
@@ -98,7 +98,7 @@
   \ifbeamer@sb@subsection%
     \begin{beamercolorbox}[ignorebg,ht=2.125ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{subsection in head/foot}
-      \usebeamerfont{subsection in head/foot}\insertsubsectionhead
+      \usebeamerfont{subsection in head/foot}\usebeamertemplate{subsection in head/foot}
     \end{beamercolorbox}%
     \vskip-0.1ex%
   \fi%

--- a/base/themes/outer/beamerouterthemesmoothtree.sty
+++ b/base/themes/outer/beamerouterthemesmoothtree.sty
@@ -71,12 +71,12 @@
   \begin{beamercolorbox}[wd=\paperwidth,ht=2.125ex,dp=1.125ex,ignorebg,%
     leftskip=.3cm,rightskip=.3cm plus1fil]{section in head/foot}
     \usebeamerfont{section in head/foot}%
-    \hskip6pt\insertsectionhead
+    \hskip6pt\usebeamertemplate{section in head/foot}
   \end{beamercolorbox}
   \begin{beamercolorbox}[wd=\paperwidth,ht=2.125ex,dp=1.125ex,ignorebg,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{subsection in head/foot}
     \usebeamerfont{subsection in head/foot}%
-    \hskip12pt\insertsubsectionhead
+    \hskip12pt\usebeamertemplate{subsection in head/foot}
   \end{beamercolorbox}
   \vskip-0.4ex%
 }

--- a/base/themes/outer/beamerouterthemetree.sty
+++ b/base/themes/outer/beamerouterthemetree.sty
@@ -30,7 +30,7 @@
     \begin{beamercolorbox}[wd=\paperwidth,ht=2.5ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{section in head/foot}
       \ifbeamer@tree@showhooks
-        \setbox\beamer@tempbox=\hbox{\insertsectionhead}%
+        \setbox\beamer@tempbox=\hbox{\usebeamertemplate{section in head/foot}}%
         \ifdim\wd\beamer@tempbox>1pt%
           \hskip2pt\raise1.9pt\hbox{\vrule width0.4pt height1.875ex\vrule width 5pt height0.4pt}%
           \hskip1pt%
@@ -38,13 +38,13 @@
       \else%  
         \hskip6pt%
       \fi%
-      \insertsectionhead
+      \usebeamertemplate{section in head/foot}
     \end{beamercolorbox}}
     {\usebeamerfont{subsection in head/foot}%
     \begin{beamercolorbox}[wd=\paperwidth,ht=2.5ex,dp=1.125ex,%
       leftskip=.3cm,rightskip=.3cm plus1fil]{subsection in head/foot}
       \ifbeamer@tree@showhooks
-        \setbox\beamer@tempbox=\hbox{\insertsubsectionhead}%
+        \setbox\beamer@tempbox=\hbox{\usebeamertemplate{subsection in head/foot}}%
         \ifdim\wd\beamer@tempbox>1pt%
           \hskip9.4pt\raise1.9pt\hbox{\vrule width0.4pt height1.875ex\vrule width 5pt height0.4pt}%
           \hskip1pt%
@@ -52,7 +52,7 @@
       \else%  
         \hskip12pt%
       \fi%
-      \insertsubsectionhead
+      \usebeamertemplate{subsection in head/foot}
     \end{beamercolorbox}}
     \begin{beamercolorbox}[wd=\paperwidth,colsep=1.5pt]{lower separation line head}
     \end{beamercolorbox}


### PR DESCRIPTION
Adding `section in head/foot` template to `infolines`, `smoothtree`  and `tree` templates to be consistent with other headlines and doc