### PR TITLE
Incompatibility of inmargin theme with `usepdftitle=false` option (fix #885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ a major and minor version only.
 - unified usage of `(sub)section in head/foot` template in headlines
 - simplify decision tree for `\beamer@howtotreatframe` (see #874)
 
+### Fixed
+
+- fixed problem if inmargin theme is used with the `usepdftitle=false` class option (see #885)
+
 ## [v3.71]
 
 ### Changed

--- a/base/themes/inner/beamerinnerthemeinmargin.sty
+++ b/base/themes/inner/beamerinnerthemeinmargin.sty
@@ -66,11 +66,19 @@
 }
 
 \setbeamertemplate{author}{%
-  \expandafter\ifblank\expandafter{\beamer@andstripped}{}{%
-  \begin{block}{\insertauthorindicator}
-    \usebeamercolor[fg]{author}\usebeamerfont{author}\insertauthor\par
-  \end{block}
-  }
+  \ifbeamer@autopdfinfo%
+    \expandafter\ifblank\expandafter{\beamer@andstripped}{}{%
+      \begin{block}{\insertauthorindicator}
+        \usebeamercolor[fg]{author}\usebeamerfont{author}\insertauthor\par
+      \end{block}
+    }
+  \else
+    \expandafter\ifblank\expandafter{\beamer@shortauthor}{}{%
+      \begin{block}{\insertauthorindicator}
+        \usebeamercolor[fg]{author}\usebeamerfont{author}\insertauthor\par
+      \end{block}
+    }
+  \fi
 }
 
 \setbeamertemplate{institute}{%


### PR DESCRIPTION
Provisional fix - in a very specific situation, the author will be missing on the title page:
```
\documentclass[
usepdftitle=false
]{beamer}

\author[]{Lecturer Name}

\usetheme{Bergen}

\begin{document}
\maketitle
\end{document}
```