### PR TITLE
fixed spacing problem for right-aligned frametitles without background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ a major and minor version only.
 ### Fixed
 
 - fixed problem if inmargin theme is used with the `usepdftitle=false` class option (see #885)
+- fixed spacing problem for right-aligned frametitles without background colour
 
 ## [v3.71]
 

--- a/base/themes/outer/beamerouterthemedefault.sty
+++ b/base/themes/outer/beamerouterthemedefault.sty
@@ -181,9 +181,6 @@
   \end{beamercolorbox}%
 }
 
-\def\beamer@fteright{\vskip0.35cm\advance\leftskip by 1.7cm\advance\rightskip by1.7cm}
-
-
 % Frame title continuations, default
 
 \defbeamertemplate*{frametitle continuation}{default}{\insertcontinuationcountroman}


### PR DESCRIPTION
For users of the right aligned default frametitle template, beamer currently inserts additional vertical and horizontal space:

```
\documentclass{beamer}

\usepackage{lipsum}
\usepackage{ragged2e}

%\setbeamercolor{frametitle}{bg=red}
\setbeamertemplate{frametitle}[default][right]

\begin{document}

\begin{frame}
\frametitle{title title title title title title title title title title title title title title title}
  \justifying
  \lipsum[]
\end{frame}

\end{document}
```

![document-1](https://github.com/josephwright/beamer/assets/43832342/68174960-daaa-4562-87d6-4cc4c82ad0d0)

This does not seem consistent with the left aligned template:

![document-1](https://github.com/josephwright/beamer/assets/43832342/d4156476-af42-4458-89d1-c944daa00c5e)

nor with the right aligned frametitle if a background colour is set

![document-1](https://github.com/josephwright/beamer/assets/43832342/49cd400d-c2ec-456c-bd21-74c7080f197c)

--- 

### Simple fix: 

One could avoid this by removing the line

https://github.com/josephwright/beamer/blob/main/base/themes/outer/beamerouterthemedefault.sty#L184

The result would look like this:

![document-1](https://github.com/josephwright/beamer/assets/43832342/dd3f048f-7d41-4ad2-9928-95147df92f76)

---

### The question is: what was the purpose of this line?

- the line was added at the same time as the frametitle template, empty commit message 1d2dc8bcba99fcf8691d7a70a876461c24f0acff . So no clues from there
- I thought maybe for sidebar themes, but they don't seem to need the additional spacing

