### PR TITLE
doc: \pause can mess up tikzpictures

### DIFF
--- a/doc/beamerug-overlays.tex
+++ b/doc/beamerug-overlays.tex
@@ -59,7 +59,7 @@ The effect of |\pause| lasts till the next |\pause|, |\onslide|, or the end of t
 \end{verbatim}
 
 \begin{command}{\pause\oarg{number}}
-  This command causes the text following it to be shown only from the next slide on, or, if the optional \meta{number} is given, from the slide with the number \meta{number}. If the optional \meta{number} is given, the counter |beamerpauses| is set to this number. This command uses the |\onslide| command, internally. This command does \emph{not} work inside |amsmath| environments like |align|, since these do really wicked things.
+  This command causes the text following it to be shown only from the next slide on, or, if the optional \meta{number} is given, from the slide with the number \meta{number}. If the optional \meta{number} is given, the counter |beamerpauses| is set to this number. This command uses the |\onslide| command, internally. This command does \emph{not} work correctly inside |amsmath| environments like |align| and \pgfname\ environements like |tikzpicture|, since these do really wicked things.
 
   \example
 \begin{verbatim}


### PR DESCRIPTION
See for example:

- https://tex.stackexchange.com/questions/21512/pause-in-tikzpicture-breaks-footline