### PR TITLE
redefine `\hyper@natlinkbreak` to avoid problems with natbib, see https://tug.org/pipermail/tex-live/2026-March/052345.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a major and minor version only.
 
 ## [Unreleased]
 
+### Fixed
+
+- redefine `\hyper@natlinkbreak` to avoid problems with natbib, see https://tug.org/pipermail/tex-live/2026-March/052345.html 
+
 ## [v3.77]
 
 ### NEW

--- a/base/beamerbasecompatibility.sty
+++ b/base/beamerbasecompatibility.sty
@@ -40,6 +40,7 @@
   \def\hyper@nat@current{#1}%
 }
 \def\hyper@natlinkend{\hyper@linkend}
+\def\hyper@natlinkbreak#1#2{#1}
 
 \mode
 <all>


### PR DESCRIPTION
Test document:

```
\begin{filecontents}{refs.bib}
@article{vaswani2017attention,
  title={Attention is all you need},
  author={Vaswani, Ashish and Shazeer, Noam and Parmar, Niki and Uszkoreit, Jakob and Jones, Llion and Gomez, Aidan N and Kaiser, {\L}ukasz and Polosukhin, Illia},
  journal={Advances in neural information processing systems},
  volume={30},
  year={2017}
}
\end{filecontents}

\documentclass{beamer}
\usepackage[authoryear,round]{natbib}

\begin{document}

\begin{frame}
Observed \citep{vaswani2017attention} (Missing comma)

Observed \citet{vaswani2017attention} (Missing parentheses around year)
\end{frame}

\begin{frame}[fragile]{References}
\bibliographystyle{plainnat}
\bibliography{refs.bib}
\end{frame}

\end{document}
```