### PR TITLE
Fix TINY font size command

### DIFF
--- a/base/beamerbasefont.sty
+++ b/base/beamerbasefont.sty
@@ -320,7 +320,7 @@
 \DeclareRobustCommand*\mit{\@fontswitch\relax\mathnormal}
 
 \newrobustcmd*\Tiny{\@setfontsize\Tiny{4}{5}}
-\newrobustcmd*\TINY{\@setfontsize\Tiny{3}{4}}
+\newrobustcmd*\TINY{\@setfontsize\TINY{3}{4}}
 
 \mode
 <article>


### PR DESCRIPTION
Fix the \TINY font command so it defines its own 3pt font size instead of redefining \Tiny.